### PR TITLE
Fix and re-enable PublishAot=true

### DIFF
--- a/Sentry.CrashReporter/App.xaml.cs
+++ b/Sentry.CrashReporter/App.xaml.cs
@@ -74,7 +74,6 @@ public partial class App : Application
                 .UseConfiguration(configure: configBuilder =>
                     configBuilder
                         .EmbeddedSource<App>()
-                        .WithConfigurationSectionFromEntity(new AppConfig { FilePath = args.Arguments })
                         .Section<AppConfig>()
                 )
             );

--- a/Sentry.CrashReporter/Sentry.CrashReporter.csproj
+++ b/Sentry.CrashReporter/Sentry.CrashReporter.csproj
@@ -3,7 +3,7 @@
         <TargetFrameworks>net9.0-desktop;net9.0</TargetFrameworks>
 
         <OutputType>Exe</OutputType>
-        <!--PublishAot>true</PublishAot-->
+        <PublishAot>true</PublishAot>
         <UnoSingleProject>true</UnoSingleProject>
 
         <!-- Display name -->


### PR DESCRIPTION
The problematic `.WithConfigurationSectionFromEntity` is no longer needed since https://github.com/getsentry/sentry-desktop-crash-reporter/commit/ea1339a577fc442cebe51bf4ea9befec9920f1ad.

Fixes: #1