### PR TITLE
ref: remove unused `AppConfig.FilePath`

### DIFF
--- a/Sentry.CrashReporter/App.xaml.cs
+++ b/Sentry.CrashReporter/App.xaml.cs
@@ -74,7 +74,6 @@ public partial class App : Application
                 .UseConfiguration(configure: configBuilder =>
                     configBuilder
                         .EmbeddedSource<App>()
-                        .WithConfigurationSectionFromEntity(new AppConfig { FilePath = args.Arguments })
                         .Section<AppConfig>()
                 )
             );

--- a/Sentry.CrashReporter/Models/AppConfig.cs
+++ b/Sentry.CrashReporter/Models/AppConfig.cs
@@ -3,5 +3,4 @@ namespace Sentry.CrashReporter.Models;
 public record AppConfig
 {
     public string? Environment { get; init; }
-    public string? FilePath { get; init; }
 }


### PR DESCRIPTION
Neither `AppConfig.FilePath` nor `.WithConfigurationSectionFromEntity` is needed since https://github.com/getsentry/sentry-desktop-crash-reporter/commit/ea1339a577fc442cebe51bf4ea9befec9920f1ad.

Close: #1 