### PR TITLE
chore: reduce default window size

### DIFF
--- a/Sentry.CrashReporter/App.xaml.cs
+++ b/Sentry.CrashReporter/App.xaml.cs
@@ -108,7 +108,7 @@ public partial class App : Application
 #if !__WASM__
         var scale = DisplayInformation.GetForCurrentView().RawPixelsPerViewPixel;
         MainWindow.AppWindow.Resize(new SizeInt32
-            { Width = (int)Math.Round(900 * scale), Height = (int)Math.Round(640 * scale) });
+            { Width = (int)Math.Round(900 * scale), Height = (int)Math.Round(600 * scale) });
 
         var view = ApplicationView.GetForCurrentView();
         view.SetPreferredMinSize(new Size(600, 400));


### PR DESCRIPTION
It was unnecessarily large after cleaning up the landing screen, and looked weird in screenshots...