### PR TITLE
feat: improve feedback form layout

### DIFF
--- a/Sentry.CrashReporter.RuntimeTests/FeedbackViewTests.cs
+++ b/Sentry.CrashReporter.RuntimeTests/FeedbackViewTests.cs
@@ -14,19 +14,19 @@ public class FeedbackViewTests : RuntimeTestBase
         var view = new FeedbackView();
         await LoadTestContent(view);
         
-        var nameTextBox = view.FindFirstDescendant<TextBox>(tb => tb.PlaceholderText == "Name");
-        var emailTextBox = view.FindFirstDescendant<TextBox>(tb => tb.PlaceholderText == "Email");
-        var messageTextBox = view.FindFirstDescendant<TextBox>(tb => tb.PlaceholderText == "Message");
+        var messageTextBox = view.FindFirstDescendant<TextBox>(tb => tb.Header.ToString() == "Message");
+        var nameTextBox = view.FindFirstDescendant<TextBox>(tb => tb.Header.ToString() == "Name");
+        var emailTextBox = view.FindFirstDescendant<TextBox>(tb => tb.Header.ToString() == "Email");
 
         // Assert
+        Assert.IsNotNull(messageTextBox);
+        Assert.IsFalse(messageTextBox.IsEnabled);
+
         Assert.IsNotNull(nameTextBox);
         Assert.IsFalse(nameTextBox.IsEnabled);
 
         Assert.IsNotNull(emailTextBox);
         Assert.IsFalse(emailTextBox.IsEnabled);
-
-        Assert.IsNotNull(messageTextBox);
-        Assert.IsFalse(messageTextBox.IsEnabled);
     }
 
     [TestMethod]
@@ -38,17 +38,57 @@ public class FeedbackViewTests : RuntimeTestBase
         var view = new FeedbackView();
         await LoadTestContent(view);
 
-        var nameTextBox = view.FindFirstDescendant<TextBox>(tb => tb.PlaceholderText == "Name")!;
-        var emailTextBox = view.FindFirstDescendant<TextBox>(tb => tb.PlaceholderText == "Email")!;
-        var messageTextBox = view.FindFirstDescendant<TextBox>(tb => tb.PlaceholderText == "Message")!;
+        var messageTextBox = view.FindFirstDescendant<TextBox>(tb => tb.Header.ToString() == "Message")!;
+        var nameTextBox = view.FindFirstDescendant<TextBox>(tb => tb.Header.ToString() == "Name")!;
+        var emailTextBox = view.FindFirstDescendant<TextBox>(tb => tb.Header.ToString() == "Email")!;
 
         // Act
+        messageTextBox.Text = "This is a test message.";
         nameTextBox.Text = "John Doe";
         emailTextBox.Text = "john.doe@example.com";
-        messageTextBox.Text = "This is a test message.";
 
         // Assert
         mockReporter.Verify(r => r.UpdateFeedback(It.Is<Feedback>(f => f.Name == "John Doe" && f.Email == "john.doe@example.com" && f.Message == "This is a test message.")));
+    }
+
+    [TestMethod]
+    public async Task FeedbackView_IsAvailable_True()
+    {
+        // Arrange
+        var envelope = new Envelope(new JsonObject { ["dsn"] = "https://foo@bar.com/123", ["event_id"] = "12345678901234567890123456789012" }, []);
+        _ = MockCrashReporter(envelope);
+
+        var view = new FeedbackView().Envelope(envelope);
+        await LoadTestContent(view);
+
+        var messageTextBox = view.FindFirstDescendant<TextBox>(tb => tb.Header.ToString() == "Message")!;
+        var nameTextBox = view.FindFirstDescendant<TextBox>(tb => tb.Header.ToString() == "Name")!;
+        var emailTextBox = view.FindFirstDescendant<TextBox>(tb => tb.Header.ToString() == "Email")!;
+
+        // Assert
+        Assert.IsTrue(messageTextBox.IsEnabled);
+        Assert.IsFalse(nameTextBox.IsEnabled);
+        Assert.IsFalse(emailTextBox.IsEnabled);
+    }
+
+    [TestMethod]
+    public async Task FeedbackView_IsAvailable_False()
+    {
+        // Arrange
+        var envelope = new Envelope(new JsonObject(), []);
+        _ = MockCrashReporter(envelope);
+
+        var view = new FeedbackView().Envelope(envelope);
+        await LoadTestContent(view);
+        
+        var messageTextBox = view.FindFirstDescendant<TextBox>(tb => tb.Header.ToString() == "Message")!;
+        var nameTextBox = view.FindFirstDescendant<TextBox>(tb => tb.Header.ToString() == "Name")!;
+        var emailTextBox = view.FindFirstDescendant<TextBox>(tb => tb.Header.ToString() == "Email")!;
+
+        // Assert
+        Assert.IsFalse(messageTextBox.IsEnabled);
+        Assert.IsFalse(nameTextBox.IsEnabled);
+        Assert.IsFalse(emailTextBox.IsEnabled);
     }
 
     [TestMethod]
@@ -61,33 +101,15 @@ public class FeedbackViewTests : RuntimeTestBase
         var view = new FeedbackView().Envelope(envelope);
         await LoadTestContent(view);
 
-        var nameTextBox = view.FindFirstDescendant<TextBox>(tb => tb.PlaceholderText == "Name")!;
-        var emailTextBox = view.FindFirstDescendant<TextBox>(tb => tb.PlaceholderText == "Email")!;
-        var messageTextBox = view.FindFirstDescendant<TextBox>(tb => tb.PlaceholderText == "Message")!;
+        var messageTextBox = view.FindFirstDescendant<TextBox>(tb => tb.Header.ToString() == "Message")!;
+        var nameTextBox = view.FindFirstDescendant<TextBox>(tb => tb.Header.ToString() == "Name")!;
+        var emailTextBox = view.FindFirstDescendant<TextBox>(tb => tb.Header.ToString() == "Email")!;
+
+        messageTextBox.Text = "This is a test message.";
 
         // Assert
+        Assert.IsTrue(messageTextBox.IsEnabled);
         Assert.IsTrue(nameTextBox.IsEnabled);
         Assert.IsTrue(emailTextBox.IsEnabled);
-        Assert.IsTrue(messageTextBox.IsEnabled);
-    }
-
-    [TestMethod]
-    public async Task FeedbackView_IsEnabled_False()
-    {
-        // Arrange
-        var envelope = new Envelope(new JsonObject(), []);
-        _ = MockCrashReporter(envelope);
-
-        var view = new FeedbackView().Envelope(envelope);
-        await LoadTestContent(view);
-        
-        var nameTextBox = view.FindFirstDescendant<TextBox>(tb => tb.PlaceholderText == "Name")!;
-        var emailTextBox = view.FindFirstDescendant<TextBox>(tb => tb.PlaceholderText == "Email")!;
-        var messageTextBox = view.FindFirstDescendant<TextBox>(tb => tb.PlaceholderText == "Message")!;
-
-        // Assert
-        Assert.IsFalse(nameTextBox.IsEnabled);
-        Assert.IsFalse(emailTextBox.IsEnabled);
-        Assert.IsFalse(messageTextBox.IsEnabled);
     }
 }

--- a/Sentry.CrashReporter.UITests/UITests.cs
+++ b/Sentry.CrashReporter.UITests/UITests.cs
@@ -70,9 +70,9 @@ public class UITests : TestBase
                 .WithBody("{\"id\":\"abcd1234\"}"));
 
         // Act
+        App.EnterText(App.Marked("messageTextBox"), "It crashed!");
         App.EnterText(App.Marked("nameTextBox"), "John Doe");
         App.EnterText(App.Marked("emailTextBox"), "john.doe@example.com");
-        App.EnterText(App.Marked("messageTextBox"), "It crashed!");
         App.Tap(App.Marked("submitButton"));
         await WaitUntilAsync(() => server.LogEntries.Count >= 2, TimeSpan.FromSeconds(30));
 
@@ -198,9 +198,9 @@ public class UITests : TestBase
                 .WithBody("{\"id\":\"abcd1234\"}"));
 
         // Act
+        App.EnterText(App.Marked("messageTextBox"), "It crashed!");
         App.EnterText(App.Marked("nameTextBox"), "John Doe");
         App.EnterText(App.Marked("emailTextBox"), "john.doe@example.com");
-        App.EnterText(App.Marked("messageTextBox"), "It crashed!");
         App.Tap(App.Marked("submitButton"));
         await WaitUntilAsync(() => server.LogEntries.Count >= 3, TimeSpan.FromSeconds(30));
 

--- a/Sentry.CrashReporter/ViewModels/FeedbackViewModel.cs
+++ b/Sentry.CrashReporter/ViewModels/FeedbackViewModel.cs
@@ -7,6 +7,7 @@ public partial class FeedbackViewModel : ReactiveObject
     [Reactive] private Envelope? _envelope;
     [ObservableAsProperty] private string? _dsn;
     [ObservableAsProperty] private string? _eventId;
+    [ObservableAsProperty] private bool _isAvailable;
     [ObservableAsProperty] private bool _isEnabled;
     [Reactive] private string _message = string.Empty;
     [Reactive] private string? _email;
@@ -28,7 +29,10 @@ public partial class FeedbackViewModel : ReactiveObject
         _eventIdHelper = this.WhenAnyValue(x => x.Envelope, e => e?.TryGetEventId())
             .ToProperty(this, x => x.EventId);
 
-        _isEnabledHelper = this.WhenAnyValue(x => x.Dsn, y => y.EventId, (x, y) => !string.IsNullOrWhiteSpace(x) && !string.IsNullOrWhiteSpace(y))
+        _isAvailableHelper = this.WhenAnyValue(x => x.Dsn, y => y.EventId, (x, y) => !string.IsNullOrWhiteSpace(x) && !string.IsNullOrWhiteSpace(y))
+            .ToProperty(this, x => x.IsAvailable);
+
+        _isEnabledHelper = this.WhenAnyValue(x => x.IsAvailable, y => y.Message, (a, m) => a && !string.IsNullOrWhiteSpace(m))
             .ToProperty(this, x => x.IsEnabled);
 
         this.WhenAnyValue(x => x.Name, x => x.Email, x => x.Message)

--- a/Sentry.CrashReporter/Views/FeedbackView.cs
+++ b/Sentry.CrashReporter/Views/FeedbackView.cs
@@ -26,29 +26,33 @@ public sealed class FeedbackView : ReactiveUserControl<FeedbackViewModel>
         this.Content(new ScrollViewer()
             .DataContext(ViewModel, (view, vm) => view
                 .Content(new Grid()
-                    .RowSpacing(8)
-                    .RowDefinitions("Auto,Auto,Auto,*")
+                    .RowSpacing(16)
+                    .RowDefinitions("*,Auto,Auto")
                     .Children(
                         new TextBox()
-                            .PlaceholderText("Name")
-                            .AutomationProperties(automationId: "nameTextBox")
-                            .IsEnabled(x => x.Binding(() => vm.IsEnabled))
-                            .Text(x => x.Binding(() => vm.Name).TwoWay())
-                            .Grid(row: 1),
-                        new TextBox()
-                            .PlaceholderText("Email")
-                            .AutomationProperties(automationId: "emailTextBox")
-                            .IsEnabled(x => x.Binding(() => vm.IsEnabled))
-                            .Text(x => x.Binding(() => vm.Email).TwoWay())
-                            .Grid(row: 2),
-                        new TextBox()
-                            .PlaceholderText("Message")
+                            .Grid(row: 0)
+                            .Header("Message")
+                            .PlaceholderText("Tell us about your issue")
                             .AutomationProperties(automationId: "messageTextBox")
+                            .MaxLength(4096)
                             .AcceptsReturn(true)
                             .TextWrapping(TextWrapping.Wrap)
-                            .Text(x => x.Binding(() => vm.Message).TwoWay())
+                            .IsEnabled(x => x.Binding(() => vm.IsAvailable))
+                            .Text(x => x.Binding(() => vm.Message).TwoWay().UpdateSourceTrigger(UpdateSourceTrigger.PropertyChanged))
+                            .VerticalAlignment(VerticalAlignment.Stretch),
+                        new TextBox()
+                            .Grid(row: 1)
+                            .Header("Name")
+                            .PlaceholderText("Your name (optional)")
+                            .AutomationProperties(automationId: "nameTextBox")
                             .IsEnabled(x => x.Binding(() => vm.IsEnabled))
-                            .VerticalAlignment(VerticalAlignment.Stretch)
-                            .Grid(row: 3)))));
+                            .Text(x => x.Binding(() => vm.Name).TwoWay().UpdateSourceTrigger(UpdateSourceTrigger.PropertyChanged)),
+                        new TextBox()
+                            .Grid(row: 2)
+                            .Header("Email")
+                            .PlaceholderText("Contact email (optional)")
+                            .AutomationProperties(automationId: "emailTextBox")
+                            .IsEnabled(x => x.Binding(() => vm.IsEnabled))
+                            .Text(x => x.Binding(() => vm.Email).TwoWay().UpdateSourceTrigger(UpdateSourceTrigger.PropertyChanged))))));
     }
 }


### PR DESCRIPTION
Move the mandatory message to the top, and add headers for clarity now that we have more than enough space after moving all the details into separate tabs.

| Before | After |
|---|---|
| <img width="2044" height="1522" alt="image" src="https://github.com/user-attachments/assets/8d753ac3-37ed-4026-8f89-af61b9b806ee" /> | <img width="2044" height="1522" alt="image" src="https://github.com/user-attachments/assets/16606fca-8f90-4033-99d6-787aa0a4f9f6" /> |

Idea shamelessly stolen from :)
- https://github.com/getsentry/sentry-godot/pull/422