### PR TITLE
ci: auto-label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,21 +8,26 @@ changelog:
   categories:
     - title: Breaking Changes
       labels:
-        - "Changelog: Breaking Change"
+        - breaking
       commit_patterns:
         - "^(?<type>\\w+(?:\\((?<scope>[^)]+)\\))?!:\\s*)"
     - title: Features
       labels:
-        - "Changelog: Feature"
+        - feature
       commit_patterns:
         - "^feat(?:\\([^\\)]+\\))?:\\s+"
     - title: Fixes
       labels:
-        - "Changelog: Bugfix"
+        - fix
       commit_patterns:
-        - "^(?:fix|bugfix)(?:\\([^\\)]+\\))?:\\s+"
+        - "^fix(?:\\([^\\)]+\\))?:\\s+"
+    - title: Improvements
+      labels:
+        - improvement
+      commit_patterns:
+        - "^perf(?:\\([^\\)]+\\))?:\\s+"
     - title: Dependencies
       labels:
-        - "Changelog: Dependency Update"
+        - dependencies
       commit_patterns:
         - "^chore\\(deps(?:-dev)?\\):\\s+"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,23 @@
+name: Auto-label
+on:
+  pull_request_target:
+    types: [opened, edited]
+permissions:
+  pull-requests: write
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add or remove skip-changelog label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Matches release.yml categories: feat, fix, perf, breaking (!), deps
+          if echo "$PR_TITLE" | grep -qP '^(feat|fix|perf)(\([^)]+\))?[!]?:\s|^\w+(\([^)]+\))?!:\s|^chore\(deps(-dev)?\):\s'; then
+            gh pr edit "$PR_NUMBER" --remove-label skip-changelog 2>/dev/null || true
+          else
+            gh pr edit "$PR_NUMBER" --add-label skip-changelog
+          fi


### PR DESCRIPTION
Add a labeler workflow that auto-applies skip-changelog to PRs whose title doesn't match a changelog category (feat, fix, perf, breaking, deps). Also add an Improvements category for perf: commits, simplify label names, and remove the unused bugfix prefix.

https://develop.sentry.dev/engineering-practices/commit-messages/