### PR TITLE
chore: configure craft artifact provider

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,9 @@
 changelogPolicy: auto
 preReleaseCommand: pwsh scripts/bump-version.ps1
+artifactProvider:
+  name: github
+  config:
+    artifacts:
+      CI: /^sentry-desktop-crash-reporter-.*$/
 targets:
   - name: github


### PR DESCRIPTION
Craft's default (legacy) artifact provider looks for a single artifact named exactly as the commit SHA, which doesn't match our per-OS/arch artifacts (`sentry-desktop-crash-reporter-<version>-<os>-<arch>`):

```
[info] Publishing version: "0.1.0"
(node:1) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[info] [[status-provider/github]] Revision fba42daa100954f98d17e0ae1f56bb4e3a6eaf42 has been built successfully.
[info] [[artifact-provider/github]] Fetching GitHub artifacts for getsentry/sentry-desktop-crash-reporter, revision fba42daa100954f98d17e0ae1f56bb4e3a6eaf42 (attempt 1 of 3)
[info] [[artifact-provider/github]] Waiting 10 seconds for artifacts to become available via GitHub API...
[info] [[artifact-provider/github]] Fetching GitHub artifacts for getsentry/sentry-desktop-crash-reporter, revision fba42daa100954f98d17e0ae1f56bb4e3a6eaf42 (attempt 2 of 3)
[info] [[artifact-provider/github]] Waiting 10 seconds for artifacts to become available via GitHub API...
[info] [[artifact-provider/github]] Fetching GitHub artifacts for getsentry/sentry-desktop-crash-reporter, revision fba42daa100954f98d17e0ae1f56bb4e3a6eaf42 (attempt 3 of 3)
Error:  [[artifact-provider/github]] Unable to retrieve artifact list for revision fba42daa100954f98d17e0ae1f56bb4e3a6eaf42!
Error:  Can't find any artifacts for revision "fba42daa100954f98d17e0ae1f56bb4e3a6eaf42" (tries: 3)
  at GitHubArtifactProvider.getRevisionArtifact (/usr/local/bin/craft:75870:15)
  at async GitHubArtifactProvider.doListArtifactsForRevision (/usr/local/bin/craft:76252:31)
  at async GitHubArtifactProvider.listArtifactsForRevision (/usr/local/bin/craft:68805:23)
  at async printRevisionSummary (/usr/local/bin/craft:167382:21)
  at async publishMain (/usr/local/bin/craft:167647:3)
  at async Object.handler2 [as handler] (/usr/local/bin/craft:167768:12)
```
https://github.com/getsentry/publish/actions/runs/24390806706/job/71236051980

Try configuring an artifact provider so that craft can hopefully find them...

Reference:

> ## GitHub Artifact Provider Configuration
> By default, the GitHub artifact provider looks for artifacts named exactly as the commit SHA. You can customize this with the `artifacts` configuration option.
>
> ### Pattern Syntax
> - **Regex patterns**: Wrapped in `/` (e.g., `/^build-.*$/`)
> - **Exact strings**: Plain text (e.g., `build`, `release-artifacts`)

https://craft.sentry.dev/configuration/#artifact-provider