### PR TITLE
ci: fix release archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,15 +65,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set Version
-        id: version
+      - name: Resolve Variables
+        id: vars
         shell: bash
         run: |
           if [[ "${{ github.ref_name }}" == release/* ]]; then
-            echo "value=${GITHUB_REF_NAME#release/}" >> "$GITHUB_OUTPUT"
+            version=${GITHUB_REF_NAME#release/}
           else
-            echo "value=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+            version=${GITHUB_SHA::7}
           fi
+          echo "artifact=sentry-desktop-crash-reporter-${version}-${{ matrix.rid }}" >> "$GITHUB_OUTPUT"
 
       - name: Install Dependencies
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
@@ -90,16 +91,15 @@ jobs:
         run: |
           mkdir ./artifacts
           if [[ "$RUNNER_OS" == "Windows" ]]; then
-            cp -r ./build/* ./artifacts/
+            (cd ./build && 7z a -tzip "../artifacts/${{ steps.vars.outputs.artifact }}.zip" .)
           else
-            # tar retains execute permissions & upload-artifact zips => works with tar zxvf
-            tar cf ./artifacts/sentry-desktop-crash-reporter-${{ steps.version.outputs.value }}-${{ matrix.rid }}.tar -C ./build .
+            tar czf "./artifacts/${{ steps.vars.outputs.artifact }}.tar.gz" -C ./build .
           fi
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: sentry-desktop-crash-reporter-${{ steps.version.outputs.value }}-${{ matrix.rid }}
+          name: ${{ steps.vars.outputs.artifact }}
           path: ./artifacts
 
       - name: Upload Binlog


### PR DESCRIPTION
Craft's GitHub artifact provider unzips every GH Actions artifact and uploads each inner file as its own release asset.

Windows jobs copied loose exe/pdb files into the upload directory, so win-x64 and win-arm64 ended up clobbering each other on the release page since their filenames are identical. Wrap Windows output in a single .zip (via the preinstalled 7z) so each build produces one self- contained release asset, matching the Unix pattern.

Switch the Unix tar to the standard .tar.gz extension so archives are consistently named across platforms, and hoist the artifact base name into a step output so the Archive and Upload steps share one definition.