### PR TITLE
fix: Toast.Show overload resolution

### DIFF
--- a/Sentry.CrashReporter.RuntimeTests/ToastTests.cs
+++ b/Sentry.CrashReporter.RuntimeTests/ToastTests.cs
@@ -22,6 +22,7 @@ public class ToastTests : RuntimeTestBase
         Assert.AreSame(button, toast.Target);
         Assert.AreEqual(title, toast.Title);
         Assert.AreEqual(subtitle, toast.Subtitle);
+        await UnitTestsUIContentHelper.WaitForIdle();
         Assert.IsTrue(toast.IsOpen);
 
         await showTask;
@@ -41,6 +42,7 @@ public class ToastTests : RuntimeTestBase
 
         var toast = FindToast(button);
         Assert.IsNotNull(toast);
+        await UnitTestsUIContentHelper.WaitForIdle();
         Assert.IsTrue(toast.IsOpen);
 
         Toast.Hide();

--- a/Sentry.CrashReporter/Controls/Toast.cs
+++ b/Sentry.CrashReporter/Controls/Toast.cs
@@ -56,8 +56,9 @@ public static class Toast
 
         // ReSharper disable once MethodHasAsyncOverload
         _hideCts?.Cancel();
-        _hideCts = new CancellationTokenSource();
-        var token = _hideCts.Token;
+        var cts = new CancellationTokenSource();
+        _hideCts = cts;
+        var token = cts.Token;
 
         _toast.DispatcherQueue.TryEnqueue(() =>
         {
@@ -68,8 +69,9 @@ public static class Toast
         try
         {
             await Task.Delay(duration ?? TimeSpan.FromSeconds(3), token);
-            _hideCts.Cancel();
-            _toast.IsOpen = false;
+            cts.Cancel();
+            if (ReferenceEquals(_hideCts, cts))
+                _toast.IsOpen = false;
         }
         catch (OperationCanceledException)
         {

--- a/Sentry.CrashReporter/Controls/Toast.cs
+++ b/Sentry.CrashReporter/Controls/Toast.cs
@@ -48,12 +48,13 @@ public static class Toast
         _toast.Title = title;
         _toast.Subtitle = subtitle;
         _toast.PreferredPlacement = placement;
-        _toast.IsOpen = true;
 
         if (target is not null)
             _toast.Target = target;
         else
             _toast.ClearValue(TeachingTip.TargetProperty);
+
+        _toast.DispatcherQueue.TryEnqueue(() => _toast.IsOpen = true);
 
         // ReSharper disable once MethodHasAsyncOverload
         _hideCts?.Cancel();

--- a/Sentry.CrashReporter/Controls/Toast.cs
+++ b/Sentry.CrashReporter/Controls/Toast.cs
@@ -68,6 +68,7 @@ public static class Toast
         try
         {
             await Task.Delay(duration ?? TimeSpan.FromSeconds(3), token);
+            _hideCts.Cancel();
             _toast.IsOpen = false;
         }
         catch (OperationCanceledException)

--- a/Sentry.CrashReporter/Controls/Toast.cs
+++ b/Sentry.CrashReporter/Controls/Toast.cs
@@ -14,7 +14,7 @@ public static class Toast
         while (current is not null)
         {
             if (current is Page { Content: Panel root })
-                return Show(root, null, title, subtitle);
+                return Show(root, title, subtitle, null);
             current = VisualTreeHelper.GetParent(current);
         }
         return Task.CompletedTask;
@@ -24,7 +24,7 @@ public static class Toast
         FrameworkElement context,
         string title,
         string subtitle,
-        FrameworkElement? target = null,
+        FrameworkElement? target,
         TeachingTipPlacementMode placement = TeachingTipPlacementMode.Bottom,
         TimeSpan? duration = null)
     {

--- a/Sentry.CrashReporter/Controls/Toast.cs
+++ b/Sentry.CrashReporter/Controls/Toast.cs
@@ -54,12 +54,16 @@ public static class Toast
         else
             _toast.ClearValue(TeachingTip.TargetProperty);
 
-        _toast.DispatcherQueue.TryEnqueue(() => _toast.IsOpen = true);
-
         // ReSharper disable once MethodHasAsyncOverload
         _hideCts?.Cancel();
         _hideCts = new CancellationTokenSource();
         var token = _hideCts.Token;
+
+        _toast.DispatcherQueue.TryEnqueue(() =>
+        {
+            if (!token.IsCancellationRequested)
+                _toast.IsOpen = true;
+        });
 
         try
         {


### PR DESCRIPTION
The null arg was misplaced, mapping subtitle onto the FrameworkElement? target parameter. Moving null to the 4th position disambiguates to the full overload. #115 merged with a stale base so CI didn't catch it.