### PR TITLE
fix: disable UnoXamlResourcesTrimming to preserve DataGrid row identity

### DIFF
--- a/Sentry.CrashReporter/Sentry.CrashReporter.csproj
+++ b/Sentry.CrashReporter/Sentry.CrashReporter.csproj
@@ -52,7 +52,7 @@
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
         <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
 
-        <UnoXamlResourcesTrimming>true</UnoXamlResourcesTrimming>
+        <UnoXamlResourcesTrimming>false</UnoXamlResourcesTrimming>
         <PublishTrimmed>true</PublishTrimmed>
         <publishSingleFile>true</publishSingleFile>
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>


### PR DESCRIPTION
Combining `UnoXamlResourcesTrimming=true` with `PublishTrimmed=true` in published desktop builds collapses all `DataGrid` rows to a single identity: hovering one row highlights all, selecting one selects all. Affects every `DataGrid` (`JsonGrid`, stacktrace, contexts, tags, ...). Reproduced with Uno.Sdk 6.3.28 and 6.5.31; either flag alone is fine.

https://platform.uno/docs/articles/features/resources-trimming.html