### PR TITLE
build: produce .app bundle on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             (cd ./build && 7z a -tzip "../artifacts/${{ steps.vars.outputs.artifact }}.zip" .)
           elif [[ "$RUNNER_OS" == "macOS" ]]; then
-            tar czf "./artifacts/${{ steps.vars.outputs.artifact }}.tar.gz" -C ./build Sentry.CrashReporter.app
+            tar czf "./artifacts/${{ steps.vars.outputs.artifact }}.tar.gz" -C ./build "Sentry Crash Reporter.app"
           else
             tar czf "./artifacts/${{ steps.vars.outputs.artifact }}.tar.gz" -C ./build .
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
           mkdir ./artifacts
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             (cd ./build && 7z a -tzip "../artifacts/${{ steps.vars.outputs.artifact }}.zip" .)
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            tar czf "./artifacts/${{ steps.vars.outputs.artifact }}.tar.gz" -C ./build Sentry.CrashReporter.app
           else
             tar czf "./artifacts/${{ steps.vars.outputs.artifact }}.tar.gz" -C ./build .
           fi

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ dotnet publish -f net9.0-desktop -r <RID> Sentry.CrashReporter/Sentry.CrashRepor
 
 Replace `<RID>` with your target platform runtime identifier (e.g., `win-x64`, `osx-arm64`, `linux-x64`). See the [.NET RID Catalog](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog) for more options.
 
-The published artifacts are written to `Sentry.CrashReporter/bin/Release/net9.0-desktop/<RID>/publish/`.
+The published artifacts are written to `Sentry.CrashReporter/bin/Release/net9.0-desktop/<RID>/publish/`. On macOS (`osx-*` RIDs), the output is an `.app` bundle (`Sentry.CrashReporter.app`) ready to be launched with `open -a`.
 
-See the [.NET deployment docs](https://learn.microsoft.com/en-us/dotnet/core/deploying) and the [Uno Platform desktop publishing guide](https://platform.uno/docs/articles/uno-publishing-desktop.html) for more details.
+See the [.NET deployment docs](https://learn.microsoft.com/en-us/dotnet/core/deploying), the [Uno Platform desktop publishing guide](https://platform.uno/docs/articles/uno-publishing-desktop.html), and the [macOS app bundle guide](https://platform.uno/docs/articles/uno-publishing-desktop-macos.html) for more details.
 
 ## Usage
 
@@ -63,3 +63,5 @@ sentry_options_set_external_crash_reporter_path(options, "/path/to/Sentry.CrashR
 /* ... */
 sentry_init(options);
 ```
+
+On macOS, point the path at the `.app` bundle itself (e.g. `/Applications/Sentry.CrashReporter.app`); `sentry-native` will launch it via `open -a` so window activation works correctly.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ dotnet publish -f net9.0-desktop -r <RID> Sentry.CrashReporter/Sentry.CrashRepor
 
 Replace `<RID>` with your target platform runtime identifier (e.g., `win-x64`, `osx-arm64`, `linux-x64`). See the [.NET RID Catalog](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog) for more options.
 
-The published artifacts are written to `Sentry.CrashReporter/bin/Release/net9.0-desktop/<RID>/publish/`. On macOS (`osx-*` RIDs), the output is an `.app` bundle (`Sentry.CrashReporter.app`) ready to be launched with `open -a`.
+The published artifacts are written to `Sentry.CrashReporter/bin/Release/net9.0-desktop/<RID>/publish/`. On macOS (`osx-*` RIDs), the output is an `.app` bundle (`Sentry Crash Reporter.app`).
 
 See the [.NET deployment docs](https://learn.microsoft.com/en-us/dotnet/core/deploying), the [Uno Platform desktop publishing guide](https://platform.uno/docs/articles/uno-publishing-desktop.html), and the [macOS app bundle guide](https://platform.uno/docs/articles/uno-publishing-desktop-macos.html) for more details.
 
@@ -64,4 +64,4 @@ sentry_options_set_external_crash_reporter_path(options, "/path/to/Sentry.CrashR
 sentry_init(options);
 ```
 
-On macOS, point the path at the `.app` bundle itself (e.g. `/Applications/Sentry.CrashReporter.app`); `sentry-native` will launch it via `open -a` so window activation works correctly.
+On macOS, point the path at the `.app` bundle itself (e.g. `/Applications/Sentry Crash Reporter.app`); `sentry-native` will launch it via `open -a` so window activation works correctly.

--- a/Sentry.CrashReporter.RuntimeTests.Host/Sentry.CrashReporter.RuntimeTests.Host.csproj
+++ b/Sentry.CrashReporter.RuntimeTests.Host/Sentry.CrashReporter.RuntimeTests.Host.csproj
@@ -5,9 +5,9 @@
     <UnoSingleProject>true</UnoSingleProject>
 
     <!-- Display name -->
-    <ApplicationTitle>Sentry.CrashReporter Runtime Tests Host</ApplicationTitle>
+    <ApplicationTitle>Sentry Crash Reporter Runtime Tests Host</ApplicationTitle>
     <!-- App Identifier -->
-    <ApplicationId>com.companyname.Sentry.CrashReporter.runtimetests.host</ApplicationId>
+    <ApplicationId>io.sentry.CrashReporter.RuntimeTests.Host</ApplicationId>
     <!-- Versions -->
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>

--- a/Sentry.CrashReporter/Platforms/Desktop/CommandLineArgs.cs
+++ b/Sentry.CrashReporter/Platforms/Desktop/CommandLineArgs.cs
@@ -1,0 +1,38 @@
+using System.Runtime.InteropServices;
+
+namespace Sentry.CrashReporter;
+
+internal static class CommandLineArgs
+{
+    internal static string[] Get()
+    {
+        var args = Environment.GetCommandLineArgs().Skip(1).ToArray();
+        // Uno's macOS .app launcher invokes coreclr_execute_assembly with argc=0/argv=NULL,
+        // so the managed runtime's view of argv is empty. Fall back to reading the real
+        // process argv directly via libSystem.
+        if (args.Length == 0 && OperatingSystem.IsMacOS())
+        {
+            args = NSGetArgs();
+        }
+        return args;
+    }
+
+    private static string[] NSGetArgs()
+    {
+        var argc = Marshal.ReadInt32(_NSGetArgc());
+        var argv = Marshal.ReadIntPtr(_NSGetArgv());
+        var result = new string[Math.Max(0, argc - 1)];
+        for (var i = 1; i < argc; i++)
+        {
+            var argPtr = Marshal.ReadIntPtr(argv, i * IntPtr.Size);
+            result[i - 1] = Marshal.PtrToStringUTF8(argPtr) ?? "";
+        }
+        return result;
+    }
+
+    [DllImport("libSystem.dylib")]
+    private static extern IntPtr _NSGetArgc();
+
+    [DllImport("libSystem.dylib")]
+    private static extern IntPtr _NSGetArgv();
+}

--- a/Sentry.CrashReporter/Platforms/Desktop/Info.plist
+++ b/Sentry.CrashReporter/Platforms/Desktop/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key>
+  <string>Crash Reporter</string>
+</dict>
+</plist>

--- a/Sentry.CrashReporter/Platforms/Desktop/Program.cs
+++ b/Sentry.CrashReporter/Platforms/Desktop/Program.cs
@@ -5,8 +5,10 @@ namespace Sentry.CrashReporter;
 internal class Program
 {
     [STAThread]
-    public static async Task Main(string[] args)
+    public static async Task Main()
     {
+        var args = CommandLineArgs.Get();
+
         StorageFile? file = null;
         if (args.Length == 1)
         {

--- a/Sentry.CrashReporter/Sentry.CrashReporter.csproj
+++ b/Sentry.CrashReporter/Sentry.CrashReporter.csproj
@@ -7,9 +7,9 @@
         <UnoSingleProject>true</UnoSingleProject>
 
         <!-- Display name -->
-        <ApplicationTitle>Sentry.CrashReporter</ApplicationTitle>
+        <ApplicationTitle>Sentry Crash Reporter</ApplicationTitle>
         <!-- App Identifier -->
-        <ApplicationId>com.companyname.Sentry.CrashReporter</ApplicationId>
+        <ApplicationId>io.sentry.CrashReporter</ApplicationId>
         <!-- Versions -->
         <ApplicationDisplayVersion>0.1.1</ApplicationDisplayVersion>
         <ApplicationVersion>1</ApplicationVersion>
@@ -63,6 +63,7 @@
         <PackageFormat>app</PackageFormat>
         <!-- The .app bundle's native launcher links against libcoreclr.dylib, which is incompatible with single-file publish. -->
         <PublishSingleFile>false</PublishSingleFile>
+        <UnoMacOSCustomInfoPlist>Platforms/Desktop/Info.plist</UnoMacOSCustomInfoPlist>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Sentry.CrashReporter/Sentry.CrashReporter.csproj
+++ b/Sentry.CrashReporter/Sentry.CrashReporter.csproj
@@ -59,6 +59,12 @@
         <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
     </PropertyGroup>
 
+    <PropertyGroup Condition=" $(RuntimeIdentifier.StartsWith('osx-')) ">
+        <PackageFormat>app</PackageFormat>
+        <!-- The .app bundle's native launcher links against libcoreclr.dylib, which is incompatible with single-file publish. -->
+        <PublishSingleFile>false</PublishSingleFile>
+    </PropertyGroup>
+
     <ItemGroup>
         <!-- Known cultures to include for text localization -->
         <UnoSupportedLanguage Include="en-US" />


### PR DESCRIPTION
Both sentry-native's process launcher and Crashpad detect bundles by the `.app` suffix and invoke them via `open -a <bundle> --args <envelope>` so the window activates correctly, which requires a real app bundle rather than a loose executable.

Once the reporter runs as a bundle, a second problem surfaces: Uno's macOS native launcher calls `coreclr_execute_assembly` with `argc=0`/`argv=NULL`, so neither `Main`'s args nor `Environment.GetCommandLineArgs()` expose the envelope path that `open --args` passes in. The fix reads the process argv directly via libSystem's `_NSGetArgv`.

Close: #132
Close: #139