### PR TITLE
ci: re-run labeler on PR synchronize

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: Auto-label
 on:
   pull_request_target:
-    types: [opened, edited]
+    types: [opened, edited, synchronize]
 permissions:
   pull-requests: write
 jobs:


### PR DESCRIPTION
Ensures rebased/force-pushed PRs get their skip-changelog label re-evaluated after changelog config changes.