### PR TITLE
chore: allow dependabot updates in changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,8 +3,6 @@ changelog:
   exclude:
     labels:
       - skip-changelog
-    authors:
-      - dependabot
   categories:
     - title: Breaking Changes
       labels:


### PR DESCRIPTION
Originally excluded in #109, and then forgotten to remove in #137.