### PR TITLE
test(wasm): Set X-Frame-Options to DENY in web.config

### DIFF
--- a/Sentry.CrashReporter/Platforms/WebAssembly/wwwroot/web.config
+++ b/Sentry.CrashReporter/Platforms/WebAssembly/wwwroot/web.config
@@ -6,6 +6,12 @@
 
   <system.webServer>
 
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="DENY" />
+      </customHeaders>
+    </httpProtocol>
+
     <!-- Disable compression as we're doing it through pre-compressed files -->
     <urlCompression doStaticCompression="false" doDynamicCompression="false" dynamicCompressionBeforeCache="false" />
 


### PR DESCRIPTION
The WebAssembly `web.config` did not set `X-Frame-Options`, leaving the app theoretically framable for clickjacking. The crash reporter has no legitimate framing use case, so deny all framing.

Fixes CodeQL alert: https://github.com/getsentry/sentry-desktop-crash-reporter/security/code-scanning/9