### PR TITLE
chore(deps): upgrade & migrate to .NET 10.0

### DIFF
--- a/.github/scripts/run-ui-tests.ps1
+++ b/.github/scripts/run-ui-tests.ps1
@@ -6,10 +6,10 @@ $env:UNO_UITEST_TARGETURI = "http://localhost:5000"
 $env:UNO_UITEST_CHROME_CONTAINER_MODE = $true
 $env:UNO_UITEST_DRIVER_PATH = $env:CHROMEWEBDRIVER
 
-$server = Start-Process -FilePath dotnet -ArgumentList "run --no-build -c Release -f net9.0-browserwasm --project Sentry.CrashReporter/Sentry.CrashReporter.csproj --launch-profile ""Sentry.CrashReporter (WebAssembly)""" -PassThru
+$server = Start-Process -FilePath dotnet -ArgumentList "run --no-build -c Release -f net10.0-browserwasm --project Sentry.CrashReporter/Sentry.CrashReporter.csproj --launch-profile ""Sentry.CrashReporter (WebAssembly)""" -PassThru
 try
 {
-    dotnet test --no-build -c Release -f net9.0 -l GitHubActions -l trx Sentry.CrashReporter.UITests/Sentry.CrashReporter.UITests.csproj
+    dotnet test --no-build -c Release -f net10.0 -l GitHubActions -l trx Sentry.CrashReporter.UITests/Sentry.CrashReporter.UITests.csproj
 }
 finally
 {

--- a/.github/steps/install_dependencies/action.yml
+++ b/.github/steps/install_dependencies/action.yml
@@ -9,7 +9,7 @@ inputs:
   dotnet-version:
     description: 'Installs and sets the .NET SDK Version'
     required: false
-    default: '9.0.x'
+    default: '10.0.x'
   sdkVersion:
     description: 'The version of the Windows Sdk'
     required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,9 @@ jobs:
         with:
           target-platform: "desktop"
 
-      # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
-
       - name: Build Sentry.CrashReporter (Debug)
         shell: pwsh
-        run: msbuild ./Sentry.CrashReporter/Sentry.CrashReporter.csproj /r
+        run: dotnet build -c Debug ./Sentry.CrashReporter/Sentry.CrashReporter.csproj
 
   build:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         uses: "./.github/steps/install_dependencies"
         with:
-          target-platform: "desktop"
+          target-platform: "desktop wasm"
 
       - name: Build Sentry.CrashReporter (Debug)
         shell: pwsh
@@ -155,7 +155,7 @@ jobs:
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         uses: "./.github/steps/install_dependencies"
         with:
-          target-platform: "webassembly"
+          target-platform: "wasm"
 
       - name: Build Sentry.CrashReporter (WebAssembly, Release)
         run: dotnet build -c Release -f net10.0-browserwasm -p:IsUiAutomationMappingEnabled=True Sentry.CrashReporter/Sentry.CrashReporter.csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Build Sentry.CrashReporter (Release)
         shell: pwsh
-        run: dotnet publish -f net9.0-desktop -r ${{ matrix.rid }} ./Sentry.CrashReporter/Sentry.CrashReporter.csproj -o ./build -bl:./build.binlog
+        run: dotnet publish -f net10.0-desktop -r ${{ matrix.rid }} ./Sentry.CrashReporter/Sentry.CrashReporter.csproj -o ./build -bl:./build.binlog
 
       - name: Archive Artifacts
         shell: bash
@@ -127,7 +127,7 @@ jobs:
 
       - name: Build Sentry.CrashReporter.Tests (Release)
         shell: pwsh
-        run: dotnet build ./Sentry.CrashReporter.Tests/Sentry.CrashReporter.Tests.csproj /p:Configuration=Release /p:OverrideTargetFramework=net9.0
+        run: dotnet build ./Sentry.CrashReporter.Tests/Sentry.CrashReporter.Tests.csproj /p:Configuration=Release /p:OverrideTargetFramework=net10.0
 
       - name: Run Unit Tests
         shell: pwsh
@@ -162,10 +162,10 @@ jobs:
           target-platform: "webassembly"
 
       - name: Build Sentry.CrashReporter (WebAssembly, Release)
-        run: dotnet build -c Release -f net9.0-browserwasm -p:IsUiAutomationMappingEnabled=True Sentry.CrashReporter/Sentry.CrashReporter.csproj
+        run: dotnet build -c Release -f net10.0-browserwasm -p:IsUiAutomationMappingEnabled=True Sentry.CrashReporter/Sentry.CrashReporter.csproj
 
       - name: Build Sentry.CrashReporter.UITests (Release)
-        run: dotnet build -c Release -f net9.0 Sentry.CrashReporter.UITests/Sentry.CrashReporter.UITests.csproj
+        run: dotnet build -c Release -f net10.0 Sentry.CrashReporter.UITests/Sentry.CrashReporter.UITests.csproj
 
       - name: Run UI Tests
         id: run-ui-tests
@@ -204,7 +204,7 @@ jobs:
         run: dotnet tool restore
 
       - name: Build Sentry.CrashReporter.RuntimeTests.Host (Release)
-        run: dotnet build -c Release -f net9.0-desktop Sentry.CrashReporter.RuntimeTests.Host/Sentry.CrashReporter.RuntimeTests.Host.csproj
+        run: dotnet build -c Release -f net10.0-desktop Sentry.CrashReporter.RuntimeTests.Host/Sentry.CrashReporter.RuntimeTests.Host.csproj
 
       - name: Run Runtime Tests
         env:
@@ -212,9 +212,9 @@ jobs:
           UNO_RUNTIME_TESTS_OUTPUT_PATH: Sentry.CrashReporter.RuntimeTests/TestResults/RuntimeTests.xml
         run: |
           xvfb-run -a dotnet tool run coverlet -- \
-            Sentry.CrashReporter.RuntimeTests.Host/bin/Release/net9.0-desktop/Sentry.CrashReporter.RuntimeTests.Host.dll \
+            Sentry.CrashReporter.RuntimeTests.Host/bin/Release/net10.0-desktop/Sentry.CrashReporter.RuntimeTests.Host.dll \
             --target dotnet \
-            --targetargs Sentry.CrashReporter.RuntimeTests.Host/bin/Release/net9.0-desktop/Sentry.CrashReporter.RuntimeTests.Host.dll \
+            --targetargs Sentry.CrashReporter.RuntimeTests.Host/bin/Release/net10.0-desktop/Sentry.CrashReporter.RuntimeTests.Host.dll \
             --output Sentry.CrashReporter.RuntimeTests/TestResults/ \
             --format cobertura \
             --single-hit \

--- a/.run/Sentry.CrashReporter.run.xml
+++ b/.run/Sentry.CrashReporter.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Sentry.CrashReporter (Desktop)" type="LaunchSettings" factoryName=".NET Launch Settings Profile">
     <option name="LAUNCH_PROFILE_PROJECT_FILE_PATH" value="$PROJECT_DIR$/Sentry.CrashReporter/Sentry.CrashReporter.csproj" />
-    <option name="LAUNCH_PROFILE_TFM" value="net9.0-desktop" />
+    <option name="LAUNCH_PROFILE_TFM" value="net10.0-desktop" />
     <option name="LAUNCH_PROFILE_NAME" value="Sentry.CrashReporter (Desktop)" />
     <option name="USE_EXTERNAL_CONSOLE" value="0" />
     <option name="USE_MONO" value="0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,8 +11,8 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="KaitaiStruct.Runtime.CSharp" Version="0.10.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.11.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.11.0" />

--- a/README.md
+++ b/README.md
@@ -34,24 +34,24 @@ reporter with your own logo, colors, and window title.
 
 ### Prerequisites
 
-- [.NET 9.0 SDK](https://dotnet.microsoft.com/download/dotnet/9.0) or later
+- [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) or later
 - Run [`uno-check`](https://platform.uno/docs/articles/uno-check.html) to verify and install additional requirements
 
 ### Develop
 
 ```bash
-dotnet run --project Sentry.CrashReporter/Sentry.CrashReporter.csproj -f net9.0-desktop -- Sentry.CrashReporter.Tests/data/inproc.envelope
+dotnet run --project Sentry.CrashReporter/Sentry.CrashReporter.csproj -f net10.0-desktop -- Sentry.CrashReporter.Tests/data/inproc.envelope
 ```
 
 ### Deploy
 
 ```bash
-dotnet publish -f net9.0-desktop -r <RID> Sentry.CrashReporter/Sentry.CrashReporter.csproj
+dotnet publish -f net10.0-desktop -r <RID> Sentry.CrashReporter/Sentry.CrashReporter.csproj
 ```
 
 Replace `<RID>` with your target platform runtime identifier (e.g., `win-x64`, `osx-arm64`, `linux-x64`). See the [.NET RID Catalog](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog) for more options.
 
-The published artifacts are written to `Sentry.CrashReporter/bin/Release/net9.0-desktop/<RID>/publish/`. On macOS (`osx-*` RIDs), the output is an `.app` bundle (`Sentry Crash Reporter.app`).
+The published artifacts are written to `Sentry.CrashReporter/bin/Release/net10.0-desktop/<RID>/publish/`. On macOS (`osx-*` RIDs), the output is an `.app` bundle (`Sentry Crash Reporter.app`).
 
 See the [.NET deployment docs](https://learn.microsoft.com/en-us/dotnet/core/deploying), the [Uno Platform desktop publishing guide](https://platform.uno/docs/articles/uno-publishing-desktop.html), and the [macOS app bundle guide](https://platform.uno/docs/articles/uno-publishing-desktop-macos.html) for more details.
 

--- a/Sentry.CrashReporter.RuntimeTests.Host/Sentry.CrashReporter.RuntimeTests.Host.csproj
+++ b/Sentry.CrashReporter.RuntimeTests.Host/Sentry.CrashReporter.RuntimeTests.Host.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-desktop</TargetFramework>
+    <TargetFramework>net10.0-desktop</TargetFramework>
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>
 

--- a/Sentry.CrashReporter.RuntimeTests/Sentry.CrashReporter.RuntimeTests.csproj
+++ b/Sentry.CrashReporter.RuntimeTests/Sentry.CrashReporter.RuntimeTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Sentry.CrashReporter.Tests/Sentry.CrashReporter.Tests.csproj
+++ b/Sentry.CrashReporter.Tests/Sentry.CrashReporter.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>

--- a/Sentry.CrashReporter.UITests/Sentry.CrashReporter.UITests.csproj
+++ b/Sentry.CrashReporter.UITests/Sentry.CrashReporter.UITests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>
 

--- a/Sentry.CrashReporter/Properties/launchSettings.json
+++ b/Sentry.CrashReporter/Properties/launchSettings.json
@@ -49,7 +49,7 @@
     },
     "Sentry.CrashReporter (Desktop WSL2)": {
       "commandName": "WSL2",
-      "commandLineArgs": "{ProjectDir}/bin/Debug/net9.0-desktop/Sentry.CrashReporter.dll",
+      "commandLineArgs": "{ProjectDir}/bin/Debug/net10.0-desktop/Sentry.CrashReporter.dll",
       "distributionName": "",
       "compatibleTargetFramework": "desktop"
     }

--- a/Sentry.CrashReporter/Sentry.CrashReporter.csproj
+++ b/Sentry.CrashReporter/Sentry.CrashReporter.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net9.0-browserwasm;net9.0-desktop;net9.0</TargetFrameworks>
+        <TargetFrameworks>net10.0-browserwasm;net10.0-desktop;net10.0</TargetFrameworks>
 
         <OutputType>Exe</OutputType>
         <!--PublishAot>true</PublishAot-->

--- a/Sentry.CrashReporter/Sentry.CrashReporter.csproj
+++ b/Sentry.CrashReporter/Sentry.CrashReporter.csproj
@@ -51,6 +51,7 @@
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
         <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
+        <UseSystemResourceKeys>false</UseSystemResourceKeys>
 
         <UnoXamlResourcesTrimming>false</UnoXamlResourcesTrimming>
         <PublishTrimmed>true</PublishTrimmed>

--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
     "Uno.Sdk": "6.5.31"
   },
   "sdk": {
-    "version": "9.0.100",
+    "version": "10.0.100",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }


### PR DESCRIPTION
.NET 9 was the latest stable when this project started. It is a Standard Term Support (STS) release supported for 18 months, with an end-of-life (EOL) date of November 2026.

Migrate & upgrade to .NET 10, which is a Long-Term Support (LTS) release with three years of support, and was released in November 2025.

Supersedes:
- https://github.com/getsentry/sentry-desktop-crash-reporter/pull/146

Close: #146