### PR TITLE
ci: route build(deps) to Dependencies in changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -19,14 +19,14 @@ changelog:
         - fix
       commit_patterns:
         - "^fix(?:\\([^\\)]+\\))?:\\s+"
+    - title: Dependencies
+      labels:
+        - dependencies
+      commit_patterns:
+        - "^(?:chore|build)\\(deps(?:-dev)?\\):\\s+"
     - title: Improvements
       labels:
         - improvement
       commit_patterns:
         - "^perf(?:\\([^\\)]+\\))?:\\s+"
         - "^build(?:\\([^\\)]+\\))?:\\s+"
-    - title: Dependencies
-      labels:
-        - dependencies
-      commit_patterns:
-        - "^chore\\(deps(?:-dev)?\\):\\s+"


### PR DESCRIPTION
Both chore(deps) and build(deps) describe dependency bumps, but release.yml only matched chore(deps) against the Dependencies section — build(deps) fell through to Improvements. Extend the Dependencies pattern to cover both prefixes and move it above Improvements so first-match-wins sends deps commits there.