### PR TITLE
chore(readme): remove outdated codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 # Sentry Desktop Crash Reporter
 
 [![CI](https://github.com/getsentry/sentry-desktop-crash-reporter/actions/workflows/ci.yml/badge.svg)](https://github.com/getsentry/sentry-desktop-crash-reporter/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/getsentry/sentry-desktop-crash-reporter/graph/badge.svg)](https://codecov.io/gh/getsentry/sentry-desktop-crash-reporter)
 
 A reference implementation of an external crash reporter for desktop applications using the [Sentry Native SDK](https://docs.sentry.io/platforms/native/).
 


### PR DESCRIPTION
Codecov.io hasn't been updated for a few months (missing `CODECOV_TOKEN`?)
- https://app.codecov.io/gh/getsentry/sentry-desktop-crash-reporter

There's an ongoing effort to switch to the local `getsentry/codecov-action`:
- https://github.com/getsentry/sentry-desktop-crash-reporter/pull/118