### PR TITLE
feat: Cache crash reports before closing

### DIFF
--- a/Sentry.CrashReporter.Tests/CrashReporterTests.cs
+++ b/Sentry.CrashReporter.Tests/CrashReporterTests.cs
@@ -1,5 +1,7 @@
 namespace Sentry.CrashReporter.Tests;
 
+using Path = System.IO.Path;
+
 public class CrashReporterTests
 {
     [Test]
@@ -56,6 +58,187 @@ public class CrashReporterTests
     }
 
     [Test]
+    public async Task CacheAsync_WithCacheDir_CachesEnvelopeAndMinidump()
+    {
+        // Arrange
+        var reporter = new Services.CrashReporter(new Mock<IStorageFile>().Object, new Mock<ISentryClient>().Object);
+        var cacheDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, Guid.NewGuid().ToString("N"));
+        var minidump = new byte[] { 0x01, 0x02, 0x03 };
+        var envelope = CreateCrashEnvelope(cacheDir, minidump);
+
+        try
+        {
+            // Act
+            await reporter.CacheAsync(envelope);
+
+            // Assert
+            await AssertCachedCrashEnvelope(cacheDir, minidump);
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+            {
+                Directory.Delete(cacheDir, true);
+            }
+        }
+    }
+
+    [Test]
+    public async Task SubmitAsync_WithCacheDir_WhenCrashEnvelopeSubmitFails_CachesCrashEnvelopeAndMinidump()
+    {
+        // Arrange
+        var client = new Mock<ISentryClient>();
+        client.Setup(c => c.SubmitEnvelopeAsync(It.IsAny<string>(), It.IsAny<Envelope>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("upload failed"));
+
+        var reporter = new Services.CrashReporter(new Mock<IStorageFile>().Object, client.Object);
+        var cacheDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, Guid.NewGuid().ToString("N"));
+        var minidump = new byte[] { 0x01, 0x02, 0x03 };
+        var envelope = CreateCrashEnvelope(cacheDir, minidump);
+
+        try
+        {
+            // Act
+            var ex = Assert.ThrowsAsync<HttpRequestException>(() => reporter.SubmitAsync(envelope));
+
+            // Assert
+            ex?.Message.Should().Be("upload failed");
+            await AssertCachedCrashEnvelope(cacheDir, minidump);
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+            {
+                Directory.Delete(cacheDir, true);
+            }
+        }
+    }
+
+    [Test]
+    public async Task SubmitAsync_WithCacheDir_WhenCrashEnvelopeSubmitFailsRepeatedly_CachesCrashEnvelopeOnce()
+    {
+        // Arrange
+        var client = new Mock<ISentryClient>();
+        client.Setup(c => c.SubmitEnvelopeAsync(It.IsAny<string>(), It.IsAny<Envelope>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("send failed"));
+
+        var reporter = new Services.CrashReporter(new Mock<IStorageFile>().Object, client.Object);
+        var cacheDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, Guid.NewGuid().ToString("N"));
+        var envelope = CreateCrashEnvelope(cacheDir, [0x01], eventId: null);
+
+        try
+        {
+            // Act
+            var firstException = Assert.ThrowsAsync<InvalidOperationException>(() => reporter.SubmitAsync(envelope));
+            var secondException = Assert.ThrowsAsync<InvalidOperationException>(() => reporter.SubmitAsync(envelope));
+
+            // Assert
+            firstException?.Message.Should().Be("send failed");
+            secondException?.Message.Should().Be("send failed");
+            Directory.GetFiles(cacheDir, "*.envelope").Should().HaveCount(1);
+            Directory.GetFiles(cacheDir, "*.dmp").Should().HaveCount(1);
+            client.Verify(c => c.SubmitEnvelopeAsync(It.IsAny<string>(), envelope, It.IsAny<CancellationToken>()),
+                Times.Exactly(2));
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+            {
+                Directory.Delete(cacheDir, true);
+            }
+        }
+    }
+
+    [Test]
+    public async Task SubmitAsync_WithCacheDir_WhenCrashEnvelopeSubmitSucceeds_DoesNotCacheCrashEnvelope()
+    {
+        // Arrange
+        var client = new Mock<ISentryClient>();
+        var reporter = new Services.CrashReporter(new Mock<IStorageFile>().Object, client.Object);
+        var cacheDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, Guid.NewGuid().ToString("N"));
+        var envelope = CreateCrashEnvelope(cacheDir, [0x01]);
+
+        try
+        {
+            // Act
+            await reporter.SubmitAsync(envelope);
+
+            // Assert
+            Directory.Exists(cacheDir).Should().BeFalse();
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+            {
+                Directory.Delete(cacheDir, true);
+            }
+        }
+    }
+
+    [Test]
+    public async Task CacheAsync_WithSubmittedCrashEnvelope_DoesNotCacheCrashEnvelope()
+    {
+        // Arrange
+        var client = new Mock<ISentryClient>();
+        var reporter = new Services.CrashReporter(new Mock<IStorageFile>().Object, client.Object);
+        var cacheDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, Guid.NewGuid().ToString("N"));
+        var envelope = CreateCrashEnvelope(cacheDir, [0x01]);
+
+        try
+        {
+            // Act
+            await reporter.SubmitAsync(envelope);
+            await reporter.CacheAsync(envelope);
+
+            // Assert
+            Directory.Exists(cacheDir).Should().BeFalse();
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+            {
+                Directory.Delete(cacheDir, true);
+            }
+        }
+    }
+
+    [Test]
+    public async Task CacheAsync_WithSubmittedCrashEnvelope_WhenFeedbackSubmitFails_DoesNotCacheCrashEnvelope()
+    {
+        // Arrange
+        var client = new Mock<ISentryClient>();
+        client.SetupSequence(c => c.SubmitEnvelopeAsync(
+                It.IsAny<string>(),
+                It.IsAny<Envelope>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .ThrowsAsync(new HttpRequestException("feedback failed"));
+
+        var reporter = new Services.CrashReporter(new Mock<IStorageFile>().Object, client.Object);
+        reporter.UpdateFeedback(new Feedback("John Doe", "john.doe@example.com", "It crashed!"));
+        var cacheDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, Guid.NewGuid().ToString("N"));
+        var envelope = CreateCrashEnvelope(cacheDir, [0x01]);
+
+        try
+        {
+            // Act
+            var ex = Assert.ThrowsAsync<HttpRequestException>(() => reporter.SubmitAsync(envelope));
+            await reporter.CacheAsync(envelope);
+
+            // Assert
+            ex?.Message.Should().Be("feedback failed");
+            Directory.Exists(cacheDir).Should().BeFalse();
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+            {
+                Directory.Delete(cacheDir, true);
+            }
+        }
+    }
+
+    [Test]
     [TestCase("data/two_items.envelope")]
     public async Task SubmitAsync_WithFeedback_CallsSentryClientTwice(string filePath)
     {
@@ -105,6 +288,54 @@ public class CrashReporterTests
 
         // Assert
         Assert.That(ex?.Message, Does.Match(@"\bDSN\b"));
+    }
+
+    private static Envelope CreateCrashEnvelope(
+        string cacheDir,
+        byte[] minidump,
+        string? eventId = "c993afb6b4ac48a6b61b2558e601d65d")
+    {
+        var header = new JsonObject
+        {
+            ["dsn"] = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42",
+            ["cache_dir"] = cacheDir
+        };
+        if (eventId is not null)
+        {
+            header["event_id"] = eventId;
+        }
+
+        return new Envelope(
+            header,
+            [
+                new EnvelopeItem(
+                    new JsonObject { ["type"] = "event" },
+                    Encoding.UTF8.GetBytes(new JsonObject { ["message"] = "crashed" }.ToJsonString())),
+                new EnvelopeItem(
+                    new JsonObject
+                    {
+                        ["type"] = "attachment",
+                        ["length"] = minidump.Length,
+                        ["attachment_type"] = "event.minidump",
+                        ["filename"] = "minidump.dmp"
+                    },
+                    minidump)
+            ]);
+    }
+
+    private static async Task AssertCachedCrashEnvelope(string cacheDir, byte[] minidump)
+    {
+        var envelopePath = Path.Combine(cacheDir, "c993afb6-b4ac-48a6-b61b-2558e601d65d.envelope");
+        var minidumpPath = Path.Combine(cacheDir, "c993afb6-b4ac-48a6-b61b-2558e601d65d.dmp");
+        File.Exists(envelopePath).Should().BeTrue();
+        File.Exists(minidumpPath).Should().BeTrue();
+        (await File.ReadAllBytesAsync(minidumpPath)).Should().Equal(minidump);
+
+        await using var file = File.OpenRead(envelopePath);
+        var cachedEnvelope = await Envelope.DeserializeAsync(file);
+        cachedEnvelope.Items.Should().HaveCount(1);
+        cachedEnvelope.Items.Should().NotContain(i => i.TryGetHeader("attachment_type") == "event.minidump");
+        cachedEnvelope.Items.Single().TryGetType().Should().Be("event");
     }
 }
 

--- a/Sentry.CrashReporter.Tests/CrashReporterTests.cs
+++ b/Sentry.CrashReporter.Tests/CrashReporterTests.cs
@@ -328,7 +328,7 @@ public class CrashReporterTests
         var reporter = new Services.CrashReporter(new Mock<IStorageFile>().Object, client.Object);
         var rootDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, Guid.NewGuid().ToString("N"));
         var sourcePath = Path.Combine(rootDir, "external", "c993afb6-b4ac-48a6-b61b-2558e601d65d.envelope");
-        var cacheSiblingPath = Path.Combine(rootDir, "external", "c993afb6-b4ac-48a6-b61b-2558e601d65d-0.dmp");
+        var cacheSiblingPath = Path.Combine(rootDir, "external", "c993afb6-b4ac-48a6-b61b-2558e601d65d-1.dmp");
         var extraSiblingPath = Path.Combine(rootDir, "external", "c993afb6-b4ac-48a6-b61b-2558e601d65d-extra.txt");
         var nonSiblingPath = Path.Combine(rootDir, "external", "c993afb6-b4ac-48a6-b61b-2558e601d65d.dmp");
         var envelope = CreateCrashEnvelopeWithoutMinidump();
@@ -556,7 +556,7 @@ public class CrashReporterTests
     private static async Task AssertCachedCrashEnvelope(string cacheDir, byte[] minidump)
     {
         var envelopePath = Path.Combine(cacheDir, "c993afb6-b4ac-48a6-b61b-2558e601d65d.envelope");
-        var minidumpPath = Path.Combine(cacheDir, "c993afb6-b4ac-48a6-b61b-2558e601d65d-0.dmp");
+        var minidumpPath = Path.Combine(cacheDir, "c993afb6-b4ac-48a6-b61b-2558e601d65d.dmp");
         File.Exists(envelopePath).Should().BeTrue();
         File.Exists(minidumpPath).Should().BeTrue();
         (await File.ReadAllBytesAsync(minidumpPath)).Should().Equal(minidump);

--- a/Sentry.CrashReporter.Tests/CrashReporterTests.cs
+++ b/Sentry.CrashReporter.Tests/CrashReporterTests.cs
@@ -381,6 +381,7 @@ public class CrashReporterTests
 
         await using var file = File.OpenRead(envelopePath);
         var cachedEnvelope = await Envelope.DeserializeAsync(file);
+        cachedEnvelope.TryGetEventId().Should().Be("c993afb6-b4ac-48a6-b61b-2558e601d65d");
         cachedEnvelope.Items.Should().HaveCount(1);
         cachedEnvelope.Items.Should().NotContain(i => i.TryGetHeader("attachment_type") == "event.minidump");
         cachedEnvelope.Items.Single().TryGetType().Should().Be("event");

--- a/Sentry.CrashReporter.Tests/CrashReporterTests.cs
+++ b/Sentry.CrashReporter.Tests/CrashReporterTests.cs
@@ -42,19 +42,30 @@ public class CrashReporterTests
     {
         // Arrange
         var client = new Mock<ISentryClient>();
-        var file = await StorageFile.GetFileFromPathAsync(filePath);
+        var tempDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, Guid.NewGuid().ToString("N"));
+        var file = await CopyFixtureAsync(filePath, tempDir);
         var reporter = new Services.CrashReporter(file, client.Object);
 
-        // Act
-        var envelope = await reporter.LoadAsync();
-        await reporter.SubmitAsync(envelope!);
+        try
+        {
+            // Act
+            var envelope = await reporter.LoadAsync();
+            await reporter.SubmitAsync(envelope!);
 
-        // Assert
-        Assert.That(envelope, Is.Not.Null);
-        client.Verify(c => c.SubmitEnvelopeAsync(It.IsAny<string>(),
-            envelope!,
-            It.IsAny<CancellationToken>()),
-            Times.Once);
+            // Assert
+            Assert.That(envelope, Is.Not.Null);
+            client.Verify(c => c.SubmitEnvelopeAsync(It.IsAny<string>(),
+                envelope!,
+                It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
     }
 
     [Test]
@@ -79,6 +90,108 @@ public class CrashReporterTests
             if (Directory.Exists(cacheDir))
             {
                 Directory.Delete(cacheDir, true);
+            }
+        }
+    }
+
+    [Test]
+    public async Task CacheAsync_WithCacheDirAndSourceEnvelopeWithoutMinidump_MovesEnvelope()
+    {
+        // Arrange
+        var reporter = new Services.CrashReporter(new Mock<IStorageFile>().Object, new Mock<ISentryClient>().Object);
+        var rootDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, Guid.NewGuid().ToString("N"));
+        var sourcePath = Path.Combine(rootDir, "external", "c993afb6-b4ac-48a6-b61b-2558e601d65d.envelope");
+        var sourceSiblingPath = Path.Combine(rootDir, "external", "c993afb6-b4ac-48a6-b61b-2558e601d65d-extra.txt");
+        var cacheDir = Path.Combine(rootDir, "cache");
+        var envelopePath = Path.Combine(cacheDir, "c993afb6-b4ac-48a6-b61b-2558e601d65d.envelope");
+        var cacheSiblingPath = Path.Combine(cacheDir, "c993afb6-b4ac-48a6-b61b-2558e601d65d-extra.txt");
+        var envelope = CreateCrashEnvelopeWithoutMinidump(cacheDir);
+        await WriteSourceEnvelopeAsync(envelope, sourcePath);
+        await File.WriteAllBytesAsync(sourceSiblingPath, [0x04]);
+        var sourceBytes = await File.ReadAllBytesAsync(sourcePath);
+
+        try
+        {
+            // Act
+            await reporter.CacheAsync(envelope);
+
+            // Assert
+            File.Exists(sourcePath).Should().BeFalse();
+            File.Exists(envelopePath).Should().BeTrue();
+            (await File.ReadAllBytesAsync(envelopePath)).Should().Equal(sourceBytes);
+            File.Exists(sourceSiblingPath).Should().BeFalse();
+            File.Exists(cacheSiblingPath).Should().BeTrue();
+            (await File.ReadAllBytesAsync(cacheSiblingPath)).Should().Equal([0x04]);
+            Directory.GetFiles(cacheDir, "*.dmp").Should().BeEmpty();
+        }
+        finally
+        {
+            if (Directory.Exists(rootDir))
+            {
+                Directory.Delete(rootDir, true);
+            }
+        }
+    }
+
+    [Test]
+    public async Task CacheAsync_WithCacheDirAndSourceEnvelopeWithMinidump_SplitsEnvelopeAndDeletesSource()
+    {
+        // Arrange
+        var reporter = new Services.CrashReporter(new Mock<IStorageFile>().Object, new Mock<ISentryClient>().Object);
+        var rootDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, Guid.NewGuid().ToString("N"));
+        var sourcePath = Path.Combine(rootDir, "external", "c993afb6-b4ac-48a6-b61b-2558e601d65d.envelope");
+        var sourceSiblingPath = Path.Combine(rootDir, "external", "c993afb6-b4ac-48a6-b61b-2558e601d65d-extra.txt");
+        var cacheDir = Path.Combine(rootDir, "cache");
+        var envelope = CreateCrashEnvelope(cacheDir, [0x01, 0x02, 0x03]);
+        await WriteSourceEnvelopeAsync(envelope, sourcePath);
+        await File.WriteAllBytesAsync(sourceSiblingPath, [0x04]);
+
+        try
+        {
+            // Act
+            await reporter.CacheAsync(envelope);
+
+            // Assert
+            File.Exists(sourcePath).Should().BeFalse();
+            File.Exists(sourceSiblingPath).Should().BeFalse();
+            File.Exists(Path.Combine(cacheDir, Path.GetFileName(sourceSiblingPath))).Should().BeFalse();
+            await AssertCachedCrashEnvelope(cacheDir, [0x01, 0x02, 0x03]);
+        }
+        finally
+        {
+            if (Directory.Exists(rootDir))
+            {
+                Directory.Delete(rootDir, true);
+            }
+        }
+    }
+
+    [Test]
+    public async Task CacheAsync_WithoutCacheDir_DeletesSourceEnvelope()
+    {
+        // Arrange
+        var reporter = new Services.CrashReporter(new Mock<IStorageFile>().Object, new Mock<ISentryClient>().Object);
+        var rootDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, Guid.NewGuid().ToString("N"));
+        var sourcePath = Path.Combine(rootDir, "external", "c993afb6-b4ac-48a6-b61b-2558e601d65d.envelope");
+        var sourceSiblingPath = Path.Combine(rootDir, "external", "c993afb6-b4ac-48a6-b61b-2558e601d65d-extra.txt");
+        var envelope = CreateCrashEnvelopeWithoutMinidump();
+        await WriteSourceEnvelopeAsync(envelope, sourcePath);
+        await File.WriteAllBytesAsync(sourceSiblingPath, [0x04]);
+
+        try
+        {
+            // Act
+            await reporter.CacheAsync(envelope);
+
+            // Assert
+            File.Exists(sourcePath).Should().BeFalse();
+            File.Exists(sourceSiblingPath).Should().BeFalse();
+        }
+        finally
+        {
+            if (Directory.Exists(rootDir))
+            {
+                Directory.Delete(rootDir, true);
             }
         }
     }
@@ -208,6 +321,43 @@ public class CrashReporterTests
     }
 
     [Test]
+    public async Task SubmitAsync_WhenCrashEnvelopeSubmitSucceeds_DeletesSourceEnvelope()
+    {
+        // Arrange
+        var client = new Mock<ISentryClient>();
+        var reporter = new Services.CrashReporter(new Mock<IStorageFile>().Object, client.Object);
+        var rootDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, Guid.NewGuid().ToString("N"));
+        var sourcePath = Path.Combine(rootDir, "external", "c993afb6-b4ac-48a6-b61b-2558e601d65d.envelope");
+        var cacheSiblingPath = Path.Combine(rootDir, "external", "c993afb6-b4ac-48a6-b61b-2558e601d65d-0.dmp");
+        var extraSiblingPath = Path.Combine(rootDir, "external", "c993afb6-b4ac-48a6-b61b-2558e601d65d-extra.txt");
+        var nonSiblingPath = Path.Combine(rootDir, "external", "c993afb6-b4ac-48a6-b61b-2558e601d65d.dmp");
+        var envelope = CreateCrashEnvelopeWithoutMinidump();
+        await WriteSourceEnvelopeAsync(envelope, sourcePath);
+        await File.WriteAllBytesAsync(cacheSiblingPath, [0x01]);
+        await File.WriteAllBytesAsync(extraSiblingPath, [0x02]);
+        await File.WriteAllBytesAsync(nonSiblingPath, [0x03]);
+
+        try
+        {
+            // Act
+            await reporter.SubmitAsync(envelope);
+
+            // Assert
+            File.Exists(sourcePath).Should().BeFalse();
+            File.Exists(cacheSiblingPath).Should().BeFalse();
+            File.Exists(extraSiblingPath).Should().BeFalse();
+            File.Exists(nonSiblingPath).Should().BeTrue();
+        }
+        finally
+        {
+            if (Directory.Exists(rootDir))
+            {
+                Directory.Delete(rootDir, true);
+            }
+        }
+    }
+
+    [Test]
     public async Task CacheAsync_WithSubmittedCrashEnvelope_DoesNotCacheCrashEnvelope()
     {
         // Arrange
@@ -276,33 +426,44 @@ public class CrashReporterTests
     {
         // Arrange
         var client = new Mock<ISentryClient>();
-        var file = await StorageFile.GetFileFromPathAsync(filePath);
+        var tempDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, Guid.NewGuid().ToString("N"));
+        var file = await CopyFixtureAsync(filePath, tempDir);
         var reporter = new Services.CrashReporter(file, client.Object);
         var submittedEnvelopes = new List<Envelope>();
         client.Setup(c => c.SubmitEnvelopeAsync(It.IsAny<string>(), It.IsAny<Envelope>(), It.IsAny<CancellationToken>()))
             .Callback<string, Envelope, CancellationToken>((_, e, _) => submittedEnvelopes.Add(e));
         var feedback = new Feedback("John Doe", "john.doe@example.com", "It crashed!");
 
-        // Act
-        var envelope = await reporter.LoadAsync();
-        reporter.UpdateFeedback(feedback);
-        await reporter.SubmitAsync(envelope!);
+        try
+        {
+            // Act
+            var envelope = await reporter.LoadAsync();
+            reporter.UpdateFeedback(feedback);
+            await reporter.SubmitAsync(envelope!);
 
-        // Assert
-        Assert.That(envelope, Is.Not.Null);
-        Assert.That(submittedEnvelopes, Has.Count.EqualTo(2));
-        Assert.That(submittedEnvelopes[0], Is.EqualTo(envelope));
-        var feedbackEnvelope = submittedEnvelopes[1];
-        Assert.That(feedbackEnvelope.Items, Has.Count.EqualTo(1));
-        var feedbackItem = feedbackEnvelope.Items[0];
-        Assert.That(feedbackItem.Header["type"]!.GetValue<string>(), Is.EqualTo("feedback"));
-        var feedbackJson = JsonNode.Parse(feedbackItem.Payload)!.AsObject();
-        var feedbackContext = feedbackJson["contexts"]!["feedback"]!;
-        Assert.That(feedbackContext["name"]!.GetValue<string>(), Is.EqualTo(feedback.Name));
-        Assert.That(feedbackContext["contact_email"]!.GetValue<string>(), Is.EqualTo(feedback.Email));
-        Assert.That(feedbackContext["message"]!.GetValue<string>(), Is.EqualTo(feedback.Message));
-        var eventId = envelope!.TryGetEventId();
-        Assert.That(feedbackContext["associated_event_id"]!.GetValue<string>(), Is.EqualTo(eventId!.Replace("-", "")));
+            // Assert
+            Assert.That(envelope, Is.Not.Null);
+            Assert.That(submittedEnvelopes, Has.Count.EqualTo(2));
+            Assert.That(submittedEnvelopes[0], Is.EqualTo(envelope));
+            var feedbackEnvelope = submittedEnvelopes[1];
+            Assert.That(feedbackEnvelope.Items, Has.Count.EqualTo(1));
+            var feedbackItem = feedbackEnvelope.Items[0];
+            Assert.That(feedbackItem.Header["type"]!.GetValue<string>(), Is.EqualTo("feedback"));
+            var feedbackJson = JsonNode.Parse(feedbackItem.Payload)!.AsObject();
+            var feedbackContext = feedbackJson["contexts"]!["feedback"]!;
+            Assert.That(feedbackContext["name"]!.GetValue<string>(), Is.EqualTo(feedback.Name));
+            Assert.That(feedbackContext["contact_email"]!.GetValue<string>(), Is.EqualTo(feedback.Email));
+            Assert.That(feedbackContext["message"]!.GetValue<string>(), Is.EqualTo(feedback.Message));
+            var eventId = envelope!.TryGetEventId();
+            Assert.That(feedbackContext["associated_event_id"]!.GetValue<string>(), Is.EqualTo(eventId!.Replace("-", "")));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
     }
 
     [Test]
@@ -355,15 +516,20 @@ public class CrashReporterTests
             ]);
     }
 
-    private static Envelope CreateCrashEnvelopeWithoutMinidump(string cacheDir)
+    private static Envelope CreateCrashEnvelopeWithoutMinidump(string? cacheDir = null)
     {
+        var header = new JsonObject
+        {
+            ["dsn"] = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42",
+            ["event_id"] = "c993afb6b4ac48a6b61b2558e601d65d"
+        };
+        if (cacheDir is not null)
+        {
+            header["cache_dir"] = cacheDir;
+        }
+
         return new Envelope(
-            new JsonObject
-            {
-                ["dsn"] = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42",
-                ["event_id"] = "c993afb6b4ac48a6b61b2558e601d65d",
-                ["cache_dir"] = cacheDir
-            },
+            header,
             [
                 new EnvelopeItem(
                     new JsonObject { ["type"] = "event" },
@@ -371,10 +537,26 @@ public class CrashReporterTests
             ]);
     }
 
+    private static async Task WriteSourceEnvelopeAsync(Envelope envelope, string sourcePath)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(sourcePath)!);
+        await using var stream = File.Create(sourcePath);
+        await envelope.SerializeAsync(stream);
+        envelope.FilePath = sourcePath;
+    }
+
+    private static async Task<StorageFile> CopyFixtureAsync(string filePath, string tempDir)
+    {
+        Directory.CreateDirectory(tempDir);
+        var tempPath = Path.Combine(tempDir, Path.GetFileName(filePath));
+        File.Copy(filePath, tempPath);
+        return await StorageFile.GetFileFromPathAsync(tempPath);
+    }
+
     private static async Task AssertCachedCrashEnvelope(string cacheDir, byte[] minidump)
     {
         var envelopePath = Path.Combine(cacheDir, "c993afb6-b4ac-48a6-b61b-2558e601d65d.envelope");
-        var minidumpPath = Path.Combine(cacheDir, "c993afb6-b4ac-48a6-b61b-2558e601d65d.dmp");
+        var minidumpPath = Path.Combine(cacheDir, "c993afb6-b4ac-48a6-b61b-2558e601d65d-0.dmp");
         File.Exists(envelopePath).Should().BeTrue();
         File.Exists(minidumpPath).Should().BeTrue();
         (await File.ReadAllBytesAsync(minidumpPath)).Should().Equal(minidump);

--- a/Sentry.CrashReporter.Tests/CrashReporterTests.cs
+++ b/Sentry.CrashReporter.Tests/CrashReporterTests.cs
@@ -84,6 +84,38 @@ public class CrashReporterTests
     }
 
     [Test]
+    public async Task CacheAsync_WhenEnvelopeWriteFails_DoesNotCreateFinalEnvelopeAndAllowsRetry()
+    {
+        // Arrange
+        var reporter = new Services.CrashReporter(new Mock<IStorageFile>().Object, new Mock<ISentryClient>().Object);
+        var cacheDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, Guid.NewGuid().ToString("N"));
+        var envelope = CreateCrashEnvelopeWithoutMinidump(cacheDir);
+        var envelopePath = Path.Combine(cacheDir, "c993afb6-b4ac-48a6-b61b-2558e601d65d.envelope");
+
+        try
+        {
+            // Act
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+            await reporter.CacheAsync(envelope, cancellation.Token);
+
+            // Assert
+            File.Exists(envelopePath).Should().BeFalse();
+            Directory.GetFiles(cacheDir, "*.tmp").Should().BeEmpty();
+
+            await reporter.CacheAsync(envelope);
+            File.Exists(envelopePath).Should().BeTrue();
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+            {
+                Directory.Delete(cacheDir, true);
+            }
+        }
+    }
+
+    [Test]
     public async Task SubmitAsync_WithCacheDir_WhenCrashEnvelopeSubmitFails_CachesCrashEnvelopeAndMinidump()
     {
         // Arrange
@@ -320,6 +352,22 @@ public class CrashReporterTests
                         ["filename"] = "minidump.dmp"
                     },
                     minidump)
+            ]);
+    }
+
+    private static Envelope CreateCrashEnvelopeWithoutMinidump(string cacheDir)
+    {
+        return new Envelope(
+            new JsonObject
+            {
+                ["dsn"] = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42",
+                ["event_id"] = "c993afb6b4ac48a6b61b2558e601d65d",
+                ["cache_dir"] = cacheDir
+            },
+            [
+                new EnvelopeItem(
+                    new JsonObject { ["type"] = "event" },
+                    Encoding.UTF8.GetBytes(new JsonObject { ["message"] = "crashed" }.ToJsonString()))
             ]);
     }
 

--- a/Sentry.CrashReporter.Tests/CrashReporterTests.cs
+++ b/Sentry.CrashReporter.Tests/CrashReporterTests.cs
@@ -310,6 +310,44 @@ public class CrashReporterTests
     }
 
     [Test]
+    public async Task SubmitAsync_WithCacheDir_WhenCachedCrashEnvelopeSubmitSucceeds_DeletesMinidump()
+    {
+        // Arrange
+        var client = new Mock<ISentryClient>();
+        client.SetupSequence(c => c.SubmitEnvelopeAsync(
+                It.IsAny<string>(),
+                It.IsAny<Envelope>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("upload failed"))
+            .Returns(Task.CompletedTask);
+
+        var reporter = new Services.CrashReporter(new Mock<IStorageFile>().Object, client.Object);
+        var cacheDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, Guid.NewGuid().ToString("N"));
+        var envelopePath = Path.Combine(cacheDir, "c993afb6-b4ac-48a6-b61b-2558e601d65d.envelope");
+        var minidumpPath = Path.Combine(cacheDir, "c993afb6-b4ac-48a6-b61b-2558e601d65d.dmp");
+        var envelope = CreateCrashEnvelope(cacheDir, [0x01]);
+
+        try
+        {
+            // Act
+            var ex = Assert.ThrowsAsync<HttpRequestException>(() => reporter.SubmitAsync(envelope));
+            await reporter.SubmitAsync(envelope);
+
+            // Assert
+            ex?.Message.Should().Be("upload failed");
+            File.Exists(envelopePath).Should().BeFalse();
+            File.Exists(minidumpPath).Should().BeFalse();
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+            {
+                Directory.Delete(cacheDir, true);
+            }
+        }
+    }
+
+    [Test]
     public async Task SubmitAsync_WithCacheDir_WhenCrashEnvelopeSubmitSucceeds_DoesNotCacheCrashEnvelope()
     {
         // Arrange

--- a/Sentry.CrashReporter.Tests/CrashReporterTests.cs
+++ b/Sentry.CrashReporter.Tests/CrashReporterTests.cs
@@ -197,6 +197,21 @@ public class CrashReporterTests
     }
 
     [Test]
+    public async Task CacheAsync_WithoutCacheDir_WhenSourcePathIsInvalid_DoesNotThrow()
+    {
+        // Arrange
+        var reporter = new Services.CrashReporter(new Mock<IStorageFile>().Object, new Mock<ISentryClient>().Object);
+        var envelope = CreateCrashEnvelopeWithoutMinidump();
+        envelope.FilePath = "invalid\0path";
+
+        // Act
+        var action = () => reporter.CacheAsync(envelope);
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Test]
     public async Task CacheAsync_WhenEnvelopeWriteFails_DoesNotCreateFinalEnvelopeAndAllowsRetry()
     {
         // Arrange

--- a/Sentry.CrashReporter.Tests/FooterViewModelTests.cs
+++ b/Sentry.CrashReporter.Tests/FooterViewModelTests.cs
@@ -182,6 +182,31 @@ public class FooterViewModelTests
 
         // Assert
         mockReporter.Verify(x => x.SubmitAsync(It.IsAny<Envelope>(), It.IsAny<CancellationToken>()), Times.Never);
+        mockReporter.Verify(x => x.CacheAsync(It.IsAny<Envelope>(), It.IsAny<CancellationToken>()), Times.Never);
+        mockWindow.Verify(x => x.Close(), Times.Once);
+    }
+
+    [Test]
+    public async Task Cancel_WithEnvelope_CachesAndClosesWindow()
+    {
+        // Arrange
+        var envelope = new Envelope(
+            new JsonObject { ["dsn"] = "https://foo@bar.com/123" },
+            new List<EnvelopeItem>()
+        );
+        var mockReporter = new Mock<ICrashReporter>();
+        var mockWindow = new Mock<IWindowService>();
+        var viewModel = new FooterViewModel(mockReporter.Object, mockWindow.Object)
+        {
+            Envelope = envelope
+        };
+
+        // Act
+        await viewModel.CancelCommand.Execute();
+
+        // Assert
+        mockReporter.Verify(x => x.SubmitAsync(It.IsAny<Envelope>(), It.IsAny<CancellationToken>()), Times.Never);
+        mockReporter.Verify(x => x.CacheAsync(envelope, It.IsAny<CancellationToken>()), Times.Once);
         mockWindow.Verify(x => x.Close(), Times.Once);
     }
 }

--- a/Sentry.CrashReporter.Tests/FooterViewModelTests.cs
+++ b/Sentry.CrashReporter.Tests/FooterViewModelTests.cs
@@ -170,6 +170,66 @@ public class FooterViewModelTests
     }
 
     [Test]
+    public async Task Submit_DisablesWindowCloseWhileSubmitting()
+    {
+        // Arrange
+        var envelope = new Envelope(
+            new JsonObject { ["dsn"] = "https://foo@bar.com/123" },
+            new List<EnvelopeItem>()
+        );
+        var mockReporter = new Mock<ICrashReporter>();
+        var tcs = new TaskCompletionSource<object?>();
+        mockReporter.Setup(x => x.SubmitAsync(envelope, It.IsAny<CancellationToken>()))
+            .Returns(tcs.Task);
+        var mockWindow = new Mock<IWindowService>();
+
+        var viewModel = new FooterViewModel(mockReporter.Object, mockWindow.Object)
+        {
+            Envelope = envelope
+        };
+        await viewModel.SubmitCommand.CanExecute.FirstAsync();
+
+        // Act
+        var task = viewModel.SubmitCommand.Execute().ToTask();
+
+        // Assert
+        mockWindow.Verify(x => x.SetClosable(false), Times.Once);
+        mockWindow.Verify(x => x.Close(), Times.Never);
+
+        // Cleanup
+        tcs.SetResult(null);
+        await task;
+    }
+
+    [Test]
+    public async Task Submit_ReenablesWindowCloseWhenSubmitFails()
+    {
+        // Arrange
+        var envelope = new Envelope(
+            new JsonObject { ["dsn"] = "https://foo@bar.com/123" },
+            new List<EnvelopeItem>()
+        );
+        var mockReporter = new Mock<ICrashReporter>();
+        mockReporter.Setup(x => x.SubmitAsync(envelope, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Failure"));
+        var mockWindow = new Mock<IWindowService>();
+
+        var viewModel = new FooterViewModel(mockReporter.Object, mockWindow.Object)
+        {
+            Envelope = envelope
+        };
+        await viewModel.SubmitCommand.CanExecute.FirstAsync();
+
+        // Act
+        await viewModel.SubmitCommand.Execute();
+
+        // Assert
+        mockWindow.Verify(x => x.SetClosable(false), Times.Once);
+        mockWindow.Verify(x => x.SetClosable(true), Times.Once);
+        mockWindow.Verify(x => x.Close(), Times.Never);
+    }
+
+    [Test]
     public async Task Cancel_ClosesWindow()
     {
         // Arrange
@@ -208,5 +268,39 @@ public class FooterViewModelTests
         mockReporter.Verify(x => x.SubmitAsync(It.IsAny<Envelope>(), It.IsAny<CancellationToken>()), Times.Never);
         mockReporter.Verify(x => x.CacheAsync(envelope, It.IsAny<CancellationToken>()), Times.Once);
         mockWindow.Verify(x => x.Close(), Times.Once);
+    }
+
+    [Test]
+    public async Task Cancel_DoesNothingWhileSubmitting()
+    {
+        // Arrange
+        var envelope = new Envelope(
+            new JsonObject { ["dsn"] = "https://foo@bar.com/123" },
+            new List<EnvelopeItem>()
+        );
+        var mockReporter = new Mock<ICrashReporter>();
+        var tcs = new TaskCompletionSource<object?>();
+        mockReporter.Setup(x => x.SubmitAsync(envelope, It.IsAny<CancellationToken>()))
+            .Returns(tcs.Task);
+        var mockWindow = new Mock<IWindowService>();
+        var viewModel = new FooterViewModel(mockReporter.Object, mockWindow.Object)
+        {
+            Envelope = envelope
+        };
+        await viewModel.SubmitCommand.CanExecute.FirstAsync();
+
+        var submitTask = viewModel.SubmitCommand.Execute().ToTask();
+        Assert.That(viewModel.IsSubmitting, Is.True);
+
+        // Act
+        await viewModel.CancelCommand.Execute();
+
+        // Assert
+        mockReporter.Verify(x => x.CacheAsync(It.IsAny<Envelope>(), It.IsAny<CancellationToken>()), Times.Never);
+        mockWindow.Verify(x => x.Close(), Times.Never);
+
+        // Cleanup
+        tcs.SetResult(null);
+        await submitTask;
     }
 }

--- a/Sentry.CrashReporter.Tests/MainViewModelTests.cs
+++ b/Sentry.CrashReporter.Tests/MainViewModelTests.cs
@@ -11,7 +11,7 @@ public class MainViewModelTests
             .Returns(Task.FromResult<Envelope?>(null));
 
         // Act
-        var viewModel = new MainViewModel(mockReporter.Object);
+        var viewModel = new MainViewModel(mockReporter.Object, new FakeWindowService());
 
         // Assert
         Assert.That(viewModel.IsExecuting, Is.False);
@@ -38,7 +38,7 @@ public class MainViewModelTests
             .Returns(taskCompletionSource.Task);
 
         // Act
-        var viewModel = new MainViewModel(mockReporter.Object);
+        var viewModel = new MainViewModel(mockReporter.Object, new FakeWindowService());
 
         // Assert
         Assert.That(viewModel.IsExecuting, Is.True);
@@ -55,7 +55,7 @@ public class MainViewModelTests
             .Returns(envelope.Task);
 
         // Act
-        var viewModel = new MainViewModel(mockReporter.Object);
+        var viewModel = new MainViewModel(mockReporter.Object, new FakeWindowService());
         var isExecuting = new TaskCompletionSource();
         viewModel.IsExecutingChanged += (_, _) =>
         {
@@ -94,7 +94,7 @@ public class MainViewModelTests
             .Returns(Task.FromResult<Envelope?>(envelope));
 
         // Act
-        var viewModel = new MainViewModel(mockReporter.Object);
+        var viewModel = new MainViewModel(mockReporter.Object, new FakeWindowService());
 
         // Assert
         Assert.That(viewModel.Envelope, Is.EqualTo(envelope));
@@ -129,7 +129,7 @@ public class MainViewModelTests
             .Returns(Task.FromResult<Envelope?>(envelope));
 
          // Act
-        var viewModel = new MainViewModel(mockReporter.Object);
+        var viewModel = new MainViewModel(mockReporter.Object, new FakeWindowService());
 
          // Assert
         Assert.That(viewModel.Attachments, Is.Not.Null);
@@ -151,11 +151,61 @@ public class MainViewModelTests
             .ThrowsAsync(exception);
 
         // Act
-        var viewModel = new MainViewModel(mockReporter.Object);
+        var viewModel = new MainViewModel(mockReporter.Object, new FakeWindowService());
         await Task.Yield();
 
         // Assert
         Assert.That(viewModel.Error, Is.EqualTo(exception));
         mockReporter.Verify(r => r.LoadAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task MainViewModel_Closing_WithEnvelope_CachesEnvelope()
+    {
+        // Arrange
+        var envelope = new Envelope(new JsonObject(), []);
+        var mockReporter = new Mock<ICrashReporter>();
+        mockReporter.Setup(x => x.LoadAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult<Envelope?>(envelope));
+        var windowService = new FakeWindowService();
+        var viewModel = new MainViewModel(mockReporter.Object, windowService);
+        await Task.Yield();
+
+        // Act
+        await windowService.RequestCloseAsync();
+
+        // Assert
+        Assert.That(viewModel.Envelope, Is.EqualTo(envelope));
+        mockReporter.Verify(r => r.CacheAsync(envelope, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}
+
+internal class FakeWindowService : IWindowService
+{
+    public event Func<Task>? Closing;
+
+    public void Register(Window window)
+    {
+    }
+
+    public void SetClosable(bool closable)
+    {
+    }
+
+    public Task RequestCloseAsync()
+    {
+        if (Closing is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        var handlers = Closing.GetInvocationList()
+            .Cast<Func<Task>>()
+            .Select(handler => handler());
+        return Task.WhenAll(handlers);
+    }
+
+    public void Close()
+    {
     }
 }

--- a/Sentry.CrashReporter.Tests/WindowServiceTests.cs
+++ b/Sentry.CrashReporter.Tests/WindowServiceTests.cs
@@ -22,4 +22,31 @@ public class WindowServiceTests
         await act.Should().NotThrowAsync();
         handled.Should().BeTrue();
     }
+
+    [Test]
+    public async Task RequestCloseAsync_WhenAlreadyClosing_DoesNotNotifyClosingAgain()
+    {
+        // Arrange
+        var windowService = new WindowService();
+        var started = new TaskCompletionSource();
+        var resume = new TaskCompletionSource();
+        var count = 0;
+        windowService.Closing += async () =>
+        {
+            count++;
+            started.SetResult();
+            await resume.Task;
+        };
+
+        // Act
+        var firstClose = windowService.RequestCloseAsync();
+        await started.Task;
+        await windowService.RequestCloseAsync();
+        resume.SetResult();
+        await firstClose;
+        await windowService.RequestCloseAsync();
+
+        // Assert
+        count.Should().Be(1);
+    }
 }

--- a/Sentry.CrashReporter.Tests/WindowServiceTests.cs
+++ b/Sentry.CrashReporter.Tests/WindowServiceTests.cs
@@ -1,0 +1,25 @@
+namespace Sentry.CrashReporter.Tests;
+
+public class WindowServiceTests
+{
+    [Test]
+    public async Task RequestCloseAsync_WhenClosingHandlerFails_ContinuesClosing()
+    {
+        // Arrange
+        var windowService = new WindowService();
+        var handled = false;
+        windowService.Closing += () => throw new InvalidOperationException("closing failed");
+        windowService.Closing += () =>
+        {
+            handled = true;
+            return Task.CompletedTask;
+        };
+
+        // Act
+        var act = () => windowService.RequestCloseAsync();
+
+        // Assert
+        await act.Should().NotThrowAsync();
+        handled.Should().BeTrue();
+    }
+}

--- a/Sentry.CrashReporter/Properties/launchSettings.json
+++ b/Sentry.CrashReporter/Properties/launchSettings.json
@@ -15,27 +15,32 @@
     "Sentry.CrashReporter (Desktop, inproc.envelope)": {
       "commandName": "Project",
       "compatibleTargetFramework": "desktop",
-      "commandLineArgs": "$(SolutionDir)/Sentry.CrashReporter.Tests/data/inproc.envelope"
+      "commandLineArgs": "inproc.envelope",
+      "workingDirectory": "$(TargetDir)"
     },
     "Sentry.CrashReporter (Desktop, breakpad.envelope)": {
       "commandName": "Project",
       "compatibleTargetFramework": "desktop",
-      "commandLineArgs": "$(SolutionDir)/Sentry.CrashReporter.Tests/data/breakpad.envelope"
+      "commandLineArgs": "breakpad.envelope",
+      "workingDirectory": "$(TargetDir)"
     },
     "Sentry.CrashReporter (Desktop, crashpad.envelope)": {
       "commandName": "Project",
       "compatibleTargetFramework": "desktop",
-      "commandLineArgs": "$(SolutionDir)/Sentry.CrashReporter.Tests/data/crashpad.envelope"
+      "commandLineArgs": "crashpad.envelope",
+      "workingDirectory": "$(TargetDir)"
     },
     "Sentry.CrashReporter (Desktop, native.envelope)": {
       "commandName": "Project",
       "compatibleTargetFramework": "desktop",
-      "commandLineArgs": "$(SolutionDir)/Sentry.CrashReporter.Tests/data/native.envelope"
+      "commandLineArgs": "native.envelope",
+      "workingDirectory": "$(TargetDir)"
     },
     "Sentry.CrashReporter (Desktop, invalid.envelope)": {
       "commandName": "Project",
       "compatibleTargetFramework": "desktop",
-      "commandLineArgs": "$(SolutionDir)/Sentry.CrashReporter.Tests/data/invalid.envelope"
+      "commandLineArgs": "invalid.envelope",
+      "workingDirectory": "$(TargetDir)"
     },
     "Sentry.CrashReporter (WebAssembly)": {
       "commandName": "Project",

--- a/Sentry.CrashReporter/Sentry.CrashReporter.csproj
+++ b/Sentry.CrashReporter/Sentry.CrashReporter.csproj
@@ -49,6 +49,15 @@
         <Content Include="../Sentry.CrashReporter.Tests/data/inproc.envelope" />
     </ItemGroup>
 
+    <ItemGroup Condition="$(TargetFramework.Contains('desktop'))">
+        <Content Include="../Sentry.CrashReporter.Tests/data/*.envelope">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+            <Link>%(Filename)%(Extension)</Link>
+            <TargetPath>%(Filename)%(Extension)</TargetPath>
+        </Content>
+    </ItemGroup>
+
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
         <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
         <UseSystemResourceKeys>false</UseSystemResourceKeys>

--- a/Sentry.CrashReporter/Services/CrashReporter.cs
+++ b/Sentry.CrashReporter/Services/CrashReporter.cs
@@ -94,6 +94,7 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
             return;
         }
 
+        string? envelopeTempPath = null;
         try
         {
             Directory.CreateDirectory(cacheDir);
@@ -117,11 +118,27 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
             }
 
             var cachedEnvelope = new Envelope(envelope.Header, envelope.Items.Except(minidumps));
-            await using var stream = File.Create(envelopePath);
-            await cachedEnvelope.SerializeAsync(stream, cancellationToken);
+            envelopeTempPath = System.IO.Path.Combine(cacheDir, $"{eventId}.{Guid.NewGuid():N}.tmp");
+            await using (var stream = File.Create(envelopeTempPath))
+            {
+                await cachedEnvelope.SerializeAsync(stream, cancellationToken);
+            }
+            File.Move(envelopeTempPath, envelopePath);
+            envelopeTempPath = null;
         }
         catch (Exception e)
         {
+            try
+            {
+                if (envelopeTempPath is not null && File.Exists(envelopeTempPath))
+                {
+                    File.Delete(envelopeTempPath);
+                }
+            }
+            catch (Exception cleanupException)
+            {
+                this.Log().LogWarning(cleanupException, "Failed to delete temporary crash envelope cache file.");
+            }
             this.Log().LogWarning(e, "Failed to cache crash envelope.");
         }
     }

--- a/Sentry.CrashReporter/Services/CrashReporter.cs
+++ b/Sentry.CrashReporter/Services/CrashReporter.cs
@@ -124,7 +124,8 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
 
             for (var i = 0; i < minidumps.Count; i++)
             {
-                var path = System.IO.Path.Combine(cacheDir, $"{eventId}-{i}.dmp");
+                var suffix = i == 0 ? ".dmp" : $"-{i}.dmp";
+                var path = System.IO.Path.Combine(cacheDir, $"{eventId}{suffix}");
                 await File.WriteAllBytesAsync(path, minidumps[i].Payload, cancellationToken);
             }
 

--- a/Sentry.CrashReporter/Services/CrashReporter.cs
+++ b/Sentry.CrashReporter/Services/CrashReporter.cs
@@ -9,6 +9,7 @@ public interface ICrashReporter
 {
     Feedback? Feedback { get; }
     public Task<Envelope?> LoadAsync(CancellationToken cancellationToken = default);
+    public Task CacheAsync(Envelope envelope, CancellationToken cancellationToken = default);
     public Task SubmitAsync(Envelope envelope, CancellationToken cancellationToken = default);
     public void UpdateFeedback(Feedback? feedback);
 }
@@ -17,6 +18,7 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
 {
     private readonly IStorageFile? _file = file ?? App.Services.GetService<IStorageFile>();
     private readonly ISentryClient _client = client ?? App.Services.GetRequiredService<ISentryClient>();
+    private readonly HashSet<Envelope> _submittedEnvelopes = [];
     private Feedback? _feedback = ResolveFeedback();
 
     public Feedback? Feedback => _feedback;
@@ -40,7 +42,16 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
         var dsn = envelope.TryGetDsn()
                   ?? throw new InvalidOperationException("Envelope does not contain a valid DSN.");
 
-        await _client.SubmitEnvelopeAsync(dsn, envelope, cancellationToken);
+        try
+        {
+            await _client.SubmitEnvelopeAsync(dsn, envelope, cancellationToken);
+            _submittedEnvelopes.Add(envelope);
+        }
+        catch (Exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            await CacheAsync(envelope);
+            throw;
+        }
 
         if (!string.IsNullOrEmpty(_feedback?.Message))
         {
@@ -68,6 +79,63 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
     public void UpdateFeedback(Feedback? feedback)
     {
         _feedback = feedback;
+    }
+
+    public async Task CacheAsync(Envelope envelope, CancellationToken cancellationToken = default)
+    {
+        if (_submittedEnvelopes.Contains(envelope))
+        {
+            return;
+        }
+
+        string? cacheDir = envelope.TryGetHeader("cache_dir");
+        if (string.IsNullOrWhiteSpace(cacheDir))
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+
+            var eventId = GetCacheEventId(envelope);
+            var envelopePath = System.IO.Path.Combine(cacheDir, $"{eventId}.envelope");
+            if (File.Exists(envelopePath))
+            {
+                return;
+            }
+
+            var minidumps = envelope.Items
+                .Where(item => item.TryGetHeader("attachment_type") == "event.minidump")
+                .ToList();
+
+            for (var i = 0; i < minidumps.Count; i++)
+            {
+                var suffix = i == 0 ? ".dmp" : $"-{i}.dmp";
+                var path = System.IO.Path.Combine(cacheDir, $"{eventId}{suffix}");
+                await File.WriteAllBytesAsync(path, minidumps[i].Payload, cancellationToken);
+            }
+
+            var cachedEnvelope = new Envelope(envelope.Header, envelope.Items.Except(minidumps));
+            await using var stream = File.Create(envelopePath);
+            await cachedEnvelope.SerializeAsync(stream, cancellationToken);
+        }
+        catch (Exception e)
+        {
+            this.Log().LogWarning(e, "Failed to cache crash envelope.");
+        }
+    }
+
+    private static string GetCacheEventId(Envelope envelope)
+    {
+        if (Guid.TryParse(envelope.TryGetEventId(), out var eventId))
+        {
+            return eventId.ToString("D");
+        }
+
+        eventId = Guid.NewGuid();
+        envelope.Header["event_id"] = eventId.ToString("N");
+        return eventId.ToString("D");
     }
 
     private static Feedback? ResolveFeedback()

--- a/Sentry.CrashReporter/Services/CrashReporter.cs
+++ b/Sentry.CrashReporter/Services/CrashReporter.cs
@@ -145,14 +145,14 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
 
     private static string GetCacheEventId(Envelope envelope)
     {
-        if (Guid.TryParse(envelope.TryGetEventId(), out var eventId))
+        if (!Guid.TryParse(envelope.TryGetEventId(), out var eventId))
         {
-            return eventId.ToString("D");
+            eventId = Guid.NewGuid();
         }
 
-        eventId = Guid.NewGuid();
-        envelope.Header["event_id"] = eventId.ToString("N");
-        return eventId.ToString("D");
+        var eventIdString = eventId.ToString("D");
+        envelope.Header["event_id"] = eventIdString;
+        return eventIdString;
     }
 
     private static Feedback? ResolveFeedback()

--- a/Sentry.CrashReporter/Services/CrashReporter.cs
+++ b/Sentry.CrashReporter/Services/CrashReporter.cs
@@ -46,7 +46,7 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
         {
             await _client.SubmitEnvelopeAsync(dsn, envelope, cancellationToken);
             _submittedEnvelopes.Add(envelope);
-            DeleteFiles(envelope);
+            DeleteEnvelope(envelope);
         }
         catch (Exception) when (!cancellationToken.IsCancellationRequested)
         {
@@ -86,14 +86,14 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
     {
         if (_submittedEnvelopes.Contains(envelope))
         {
-            DeleteFiles(envelope);
+            DeleteEnvelope(envelope);
             return;
         }
 
         string? cacheDir = envelope.TryGetHeader("cache_dir");
         if (string.IsNullOrWhiteSpace(cacheDir))
         {
-            DeleteFiles(envelope);
+            DeleteEnvelope(envelope);
             return;
         }
 
@@ -106,7 +106,7 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
             var envelopePath = System.IO.Path.Combine(cacheDir, $"{eventId}.envelope");
             if (File.Exists(envelopePath))
             {
-                if (DeleteFiles(envelope, envelopePath))
+                if (DeleteEnvelope(envelope, envelopePath))
                 {
                     envelope.FilePath = envelopePath;
                 }
@@ -117,7 +117,7 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
                 .Where(item => item.TryGetHeader("attachment_type") == "event.minidump")
                 .ToList();
 
-            if (minidumps.Count == 0 && TryMoveFiles(envelope, envelopePath))
+            if (minidumps.Count == 0 && TryMoveEnvelope(envelope, envelopePath))
             {
                 return;
             }
@@ -136,7 +136,7 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
             }
             File.Move(envelopeTempPath, envelopePath);
             envelopeTempPath = null;
-            if (DeleteFiles(envelope, envelopePath))
+            if (DeleteEnvelope(envelope, envelopePath))
             {
                 envelope.FilePath = envelopePath;
             }
@@ -170,7 +170,7 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
         return eventIdString;
     }
 
-    private static bool TryMoveFiles(Envelope envelope, string envelopePath)
+    private static bool TryMoveEnvelope(Envelope envelope, string envelopePath)
     {
         var sourcePath = envelope.FilePath;
         if (string.IsNullOrWhiteSpace(sourcePath) || !File.Exists(sourcePath))
@@ -180,68 +180,62 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
 
         if (!SamePath(sourcePath, envelopePath))
         {
-            MoveCacheSiblings(sourcePath, envelopePath, envelope);
+            var sourceDir = System.IO.Path.GetDirectoryName(sourcePath);
+            var envelopeDir = System.IO.Path.GetDirectoryName(envelopePath);
+            if (!string.IsNullOrWhiteSpace(sourceDir) &&
+                !string.IsNullOrWhiteSpace(envelopeDir) &&
+                Directory.Exists(sourceDir) &&
+                Guid.TryParse(envelope.TryGetEventId(), out var eventId))
+            {
+                foreach (var siblingPath in Directory.EnumerateFiles(sourceDir, $"{eventId:D}-*"))
+                {
+                    var targetPath = System.IO.Path.Combine(envelopeDir, System.IO.Path.GetFileName(siblingPath));
+                    if (!SamePath(siblingPath, targetPath))
+                    {
+                        File.Move(siblingPath, targetPath);
+                    }
+                }
+            }
             File.Move(sourcePath, envelopePath);
         }
         envelope.FilePath = envelopePath;
         return true;
     }
 
-    private static void MoveCacheSiblings(string sourcePath, string envelopePath, Envelope envelope)
-    {
-        if (!Guid.TryParse(envelope.TryGetEventId(), out var eventId))
-        {
-            return;
-        }
-
-        var sourceDir = System.IO.Path.GetDirectoryName(sourcePath);
-        var envelopeDir = System.IO.Path.GetDirectoryName(envelopePath);
-        if (string.IsNullOrWhiteSpace(sourceDir) || string.IsNullOrWhiteSpace(envelopeDir) ||
-            !Directory.Exists(sourceDir))
-        {
-            return;
-        }
-
-        foreach (var siblingPath in Directory.EnumerateFiles(sourceDir, $"{eventId:D}-*"))
-        {
-            var targetPath = System.IO.Path.Combine(envelopeDir, System.IO.Path.GetFileName(siblingPath));
-            if (!SamePath(siblingPath, targetPath))
-            {
-                File.Move(siblingPath, targetPath);
-            }
-        }
-    }
-
-    private bool DeleteFiles(Envelope envelope, string? preservedPath = null)
+    private bool DeleteEnvelope(Envelope envelope, string? preservedPath = null)
     {
         var envelopePath = envelope.FilePath;
-        if (!DeleteEnvelope(envelope, preservedPath))
-        {
-            return false;
-        }
-
-        if (string.IsNullOrWhiteSpace(envelopePath) || !Guid.TryParse(envelope.TryGetEventId(), out var eventId))
+        if (string.IsNullOrWhiteSpace(envelopePath) || SamePath(envelopePath, preservedPath))
         {
             return true;
         }
 
-        if (SamePath(envelopePath, preservedPath))
+        if (File.Exists(envelopePath))
         {
-            return true;
+            try
+            {
+                File.Delete(envelopePath);
+                envelope.FilePath = null;
+            }
+            catch (Exception e)
+            {
+                this.Log().LogWarning(e, "Failed to delete consumed crash envelope.");
+                return false;
+            }
+        }
+        else
+        {
+            envelope.FilePath = null;
         }
 
         var directory = System.IO.Path.GetDirectoryName(envelopePath);
-        if (string.IsNullOrWhiteSpace(directory) || !Directory.Exists(directory))
+        if (string.IsNullOrWhiteSpace(directory) ||
+            !Directory.Exists(directory) ||
+            !Guid.TryParse(envelope.TryGetEventId(), out var eventId))
         {
             return true;
         }
 
-        DeleteCacheSiblings(directory, eventId);
-        return true;
-    }
-
-    private void DeleteCacheSiblings(string directory, Guid eventId)
-    {
         foreach (var siblingPath in Directory.EnumerateFiles(directory, $"{eventId:D}-*"))
         {
             try
@@ -253,33 +247,7 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
                 this.Log().LogWarning(e, "Failed to delete crash envelope cache sibling.");
             }
         }
-    }
-
-    private bool DeleteEnvelope(Envelope envelope, string? preservedPath = null)
-    {
-        var sourcePath = envelope.FilePath;
-        if (string.IsNullOrWhiteSpace(sourcePath) || SamePath(sourcePath, preservedPath))
-        {
-            return true;
-        }
-
-        if (!File.Exists(sourcePath))
-        {
-            envelope.FilePath = null;
-            return true;
-        }
-
-        try
-        {
-            File.Delete(sourcePath);
-            envelope.FilePath = null;
-            return true;
-        }
-        catch (Exception e)
-        {
-            this.Log().LogWarning(e, "Failed to delete consumed crash envelope.");
-            return false;
-        }
+        return true;
     }
 
     private static bool SamePath(string? left, string? right)

--- a/Sentry.CrashReporter/Services/CrashReporter.cs
+++ b/Sentry.CrashReporter/Services/CrashReporter.cs
@@ -46,6 +46,7 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
         {
             await _client.SubmitEnvelopeAsync(dsn, envelope, cancellationToken);
             _submittedEnvelopes.Add(envelope);
+            DeleteFiles(envelope);
         }
         catch (Exception) when (!cancellationToken.IsCancellationRequested)
         {
@@ -85,12 +86,14 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
     {
         if (_submittedEnvelopes.Contains(envelope))
         {
+            DeleteFiles(envelope);
             return;
         }
 
         string? cacheDir = envelope.TryGetHeader("cache_dir");
         if (string.IsNullOrWhiteSpace(cacheDir))
         {
+            DeleteFiles(envelope);
             return;
         }
 
@@ -103,6 +106,10 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
             var envelopePath = System.IO.Path.Combine(cacheDir, $"{eventId}.envelope");
             if (File.Exists(envelopePath))
             {
+                if (DeleteFiles(envelope, envelopePath))
+                {
+                    envelope.FilePath = envelopePath;
+                }
                 return;
             }
 
@@ -110,10 +117,14 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
                 .Where(item => item.TryGetHeader("attachment_type") == "event.minidump")
                 .ToList();
 
+            if (minidumps.Count == 0 && TryMoveFiles(envelope, envelopePath))
+            {
+                return;
+            }
+
             for (var i = 0; i < minidumps.Count; i++)
             {
-                var suffix = i == 0 ? ".dmp" : $"-{i}.dmp";
-                var path = System.IO.Path.Combine(cacheDir, $"{eventId}{suffix}");
+                var path = System.IO.Path.Combine(cacheDir, $"{eventId}-{i}.dmp");
                 await File.WriteAllBytesAsync(path, minidumps[i].Payload, cancellationToken);
             }
 
@@ -125,6 +136,10 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
             }
             File.Move(envelopeTempPath, envelopePath);
             envelopeTempPath = null;
+            if (DeleteFiles(envelope, envelopePath))
+            {
+                envelope.FilePath = envelopePath;
+            }
         }
         catch (Exception e)
         {
@@ -153,6 +168,133 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
         var eventIdString = eventId.ToString("D");
         envelope.Header["event_id"] = eventIdString;
         return eventIdString;
+    }
+
+    private static bool TryMoveFiles(Envelope envelope, string envelopePath)
+    {
+        var sourcePath = envelope.FilePath;
+        if (string.IsNullOrWhiteSpace(sourcePath) || !File.Exists(sourcePath))
+        {
+            return false;
+        }
+
+        if (!SamePath(sourcePath, envelopePath))
+        {
+            MoveCacheSiblings(sourcePath, envelopePath, envelope);
+            File.Move(sourcePath, envelopePath);
+        }
+        envelope.FilePath = envelopePath;
+        return true;
+    }
+
+    private static void MoveCacheSiblings(string sourcePath, string envelopePath, Envelope envelope)
+    {
+        if (!Guid.TryParse(envelope.TryGetEventId(), out var eventId))
+        {
+            return;
+        }
+
+        var sourceDir = System.IO.Path.GetDirectoryName(sourcePath);
+        var envelopeDir = System.IO.Path.GetDirectoryName(envelopePath);
+        if (string.IsNullOrWhiteSpace(sourceDir) || string.IsNullOrWhiteSpace(envelopeDir) ||
+            !Directory.Exists(sourceDir))
+        {
+            return;
+        }
+
+        foreach (var siblingPath in Directory.EnumerateFiles(sourceDir, $"{eventId:D}-*"))
+        {
+            var targetPath = System.IO.Path.Combine(envelopeDir, System.IO.Path.GetFileName(siblingPath));
+            if (!SamePath(siblingPath, targetPath))
+            {
+                File.Move(siblingPath, targetPath);
+            }
+        }
+    }
+
+    private bool DeleteFiles(Envelope envelope, string? preservedPath = null)
+    {
+        var envelopePath = envelope.FilePath;
+        if (!DeleteEnvelope(envelope, preservedPath))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(envelopePath) || !Guid.TryParse(envelope.TryGetEventId(), out var eventId))
+        {
+            return true;
+        }
+
+        if (SamePath(envelopePath, preservedPath))
+        {
+            return true;
+        }
+
+        var directory = System.IO.Path.GetDirectoryName(envelopePath);
+        if (string.IsNullOrWhiteSpace(directory) || !Directory.Exists(directory))
+        {
+            return true;
+        }
+
+        DeleteCacheSiblings(directory, eventId);
+        return true;
+    }
+
+    private void DeleteCacheSiblings(string directory, Guid eventId)
+    {
+        foreach (var siblingPath in Directory.EnumerateFiles(directory, $"{eventId:D}-*"))
+        {
+            try
+            {
+                File.Delete(siblingPath);
+            }
+            catch (Exception e)
+            {
+                this.Log().LogWarning(e, "Failed to delete crash envelope cache sibling.");
+            }
+        }
+    }
+
+    private bool DeleteEnvelope(Envelope envelope, string? preservedPath = null)
+    {
+        var sourcePath = envelope.FilePath;
+        if (string.IsNullOrWhiteSpace(sourcePath) || SamePath(sourcePath, preservedPath))
+        {
+            return true;
+        }
+
+        if (!File.Exists(sourcePath))
+        {
+            envelope.FilePath = null;
+            return true;
+        }
+
+        try
+        {
+            File.Delete(sourcePath);
+            envelope.FilePath = null;
+            return true;
+        }
+        catch (Exception e)
+        {
+            this.Log().LogWarning(e, "Failed to delete consumed crash envelope.");
+            return false;
+        }
+    }
+
+    private static bool SamePath(string? left, string? right)
+    {
+        if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right))
+        {
+            return false;
+        }
+
+        return string.Equals(
+            System.IO.Path.GetFullPath(left),
+            System.IO.Path.GetFullPath(right),
+            OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal);
     }
 
     private static Feedback? ResolveFeedback()

--- a/Sentry.CrashReporter/Services/CrashReporter.cs
+++ b/Sentry.CrashReporter/Services/CrashReporter.cs
@@ -84,22 +84,22 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
 
     public async Task CacheAsync(Envelope envelope, CancellationToken cancellationToken = default)
     {
-        if (_submittedEnvelopes.Contains(envelope))
-        {
-            DeleteEnvelope(envelope);
-            return;
-        }
-
-        string? cacheDir = envelope.TryGetHeader("cache_dir");
-        if (string.IsNullOrWhiteSpace(cacheDir))
-        {
-            DeleteEnvelope(envelope);
-            return;
-        }
-
         string? envelopeTempPath = null;
         try
         {
+            if (_submittedEnvelopes.Contains(envelope))
+            {
+                DeleteEnvelope(envelope);
+                return;
+            }
+
+            string? cacheDir = envelope.TryGetHeader("cache_dir");
+            if (string.IsNullOrWhiteSpace(cacheDir))
+            {
+                DeleteEnvelope(envelope);
+                return;
+            }
+
             Directory.CreateDirectory(cacheDir);
 
             var eventId = GetCacheEventId(envelope);

--- a/Sentry.CrashReporter/Services/CrashReporter.cs
+++ b/Sentry.CrashReporter/Services/CrashReporter.cs
@@ -237,18 +237,48 @@ public class CrashReporter(IStorageFile? file = null, ISentryClient? client = nu
             return true;
         }
 
+        if (IsCacheDirectory(directory, envelope))
+        {
+            DeleteEnvelopeSibling(System.IO.Path.Combine(directory, $"{eventId:D}.dmp"));
+        }
+
         foreach (var siblingPath in Directory.EnumerateFiles(directory, $"{eventId:D}-*"))
         {
-            try
-            {
-                File.Delete(siblingPath);
-            }
-            catch (Exception e)
-            {
-                this.Log().LogWarning(e, "Failed to delete crash envelope cache sibling.");
-            }
+            DeleteEnvelopeSibling(siblingPath);
         }
         return true;
+    }
+
+    private void DeleteEnvelopeSibling(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (Exception e)
+        {
+            this.Log().LogWarning(e, "Failed to delete crash envelope cache sibling.");
+        }
+    }
+
+    private static bool IsCacheDirectory(string directory, Envelope envelope)
+    {
+        try
+        {
+            return SamePath(directory, envelope.TryGetHeader("cache_dir"));
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+        catch (PathTooLongException)
+        {
+            return false;
+        }
     }
 
     private static bool SamePath(string? left, string? right)

--- a/Sentry.CrashReporter/Services/WindowService.cs
+++ b/Sentry.CrashReporter/Services/WindowService.cs
@@ -16,6 +16,7 @@ public class WindowService : IWindowService
     private Window? _window;
     private bool _isClosable = true;
     private bool _forceClose;
+    private bool _isClosing;
 
     public event Func<Task>? Closing;
 
@@ -33,13 +34,24 @@ public class WindowService : IWindowService
 
     public async Task RequestCloseAsync()
     {
-        if (!_isClosable)
+        if (!_isClosable || _forceClose || _isClosing)
         {
             return;
         }
+        _isClosing = true;
 
-        await NotifyClosingAsync();
-        Close();
+        try
+        {
+            await NotifyClosingAsync();
+            Close();
+        }
+        finally
+        {
+            if (!_forceClose)
+            {
+                _isClosing = false;
+            }
+        }
     }
 
     public void Close()

--- a/Sentry.CrashReporter/Services/WindowService.cs
+++ b/Sentry.CrashReporter/Services/WindowService.cs
@@ -68,7 +68,14 @@ public class WindowService : IWindowService
 
         foreach (Func<Task> handler in Closing.GetInvocationList())
         {
-            await handler();
+            try
+            {
+                await handler();
+            }
+            catch (Exception e)
+            {
+                this.Log().LogWarning(e, "Window closing handler failed.");
+            }
         }
     }
 }

--- a/Sentry.CrashReporter/Services/WindowService.cs
+++ b/Sentry.CrashReporter/Services/WindowService.cs
@@ -43,7 +43,10 @@ public class WindowService : IWindowService
         try
         {
             await NotifyClosingAsync();
-            Close();
+            if (!_forceClose)
+            {
+                Close();
+            }
         }
         finally
         {

--- a/Sentry.CrashReporter/Services/WindowService.cs
+++ b/Sentry.CrashReporter/Services/WindowService.cs
@@ -68,6 +68,7 @@ public class WindowService : IWindowService
         }
 
         args.Cancel = true;
+        await Task.Yield();
         await RequestCloseAsync();
     }
 

--- a/Sentry.CrashReporter/Services/WindowService.cs
+++ b/Sentry.CrashReporter/Services/WindowService.cs
@@ -73,12 +73,7 @@ public class WindowService : IWindowService
 
     private async Task NotifyClosingAsync()
     {
-        if (Closing is null)
-        {
-            return;
-        }
-
-        foreach (Func<Task> handler in Closing.GetInvocationList())
+        foreach (Func<Task> handler in Closing?.GetInvocationList() ?? [])
         {
             try
             {

--- a/Sentry.CrashReporter/Services/WindowService.cs
+++ b/Sentry.CrashReporter/Services/WindowService.cs
@@ -4,8 +4,10 @@ namespace Sentry.CrashReporter.Services;
 
 public interface IWindowService
 {
+    event Func<Task>? Closing;
     void Register(Window window);
     void SetClosable(bool closable);
+    Task RequestCloseAsync();
     void Close();
 }
 
@@ -14,6 +16,8 @@ public class WindowService : IWindowService
     private Window? _window;
     private bool _isClosable = true;
     private bool _forceClose;
+
+    public event Func<Task>? Closing;
 
     public void Register(Window window)
     {
@@ -27,17 +31,44 @@ public class WindowService : IWindowService
         _window?.SetClosable(closable);
     }
 
+    public async Task RequestCloseAsync()
+    {
+        if (!_isClosable)
+        {
+            return;
+        }
+
+        await NotifyClosingAsync();
+        Close();
+    }
+
     public void Close()
     {
         _forceClose = true;
         _window?.Close();
     }
 
-    private void OnClosing(Microsoft.UI.Windowing.AppWindow sender, Microsoft.UI.Windowing.AppWindowClosingEventArgs args)
+    private async void OnClosing(Microsoft.UI.Windowing.AppWindow sender, Microsoft.UI.Windowing.AppWindowClosingEventArgs args)
     {
-        if (!_isClosable && !_forceClose)
+        if (_forceClose)
         {
-            args.Cancel = true;
+            return;
+        }
+
+        args.Cancel = true;
+        await RequestCloseAsync();
+    }
+
+    private async Task NotifyClosingAsync()
+    {
+        if (Closing is null)
+        {
+            return;
+        }
+
+        foreach (Func<Task> handler in Closing.GetInvocationList())
+        {
+            await handler();
         }
     }
 }

--- a/Sentry.CrashReporter/ViewModels/FooterViewModel.cs
+++ b/Sentry.CrashReporter/ViewModels/FooterViewModel.cs
@@ -73,5 +73,13 @@ public partial class FooterViewModel : ReactiveObject
     }
 
     [ReactiveCommand]
-    private void Cancel() => _window.Close();
+    private async Task Cancel()
+    {
+        if (_envelope is not null)
+        {
+            await _reporter.CacheAsync(_envelope);
+        }
+
+        _window.Close();
+    }
 }

--- a/Sentry.CrashReporter/ViewModels/FooterViewModel.cs
+++ b/Sentry.CrashReporter/ViewModels/FooterViewModel.cs
@@ -61,6 +61,7 @@ public partial class FooterViewModel : ReactiveObject
     private async Task Submit()
     {
         ErrorMessage = null;
+        _window.SetClosable(false);
         try
         {
             await _reporter.SubmitAsync(_envelope!);
@@ -69,12 +70,18 @@ public partial class FooterViewModel : ReactiveObject
         catch (Exception e)
         {
             ErrorMessage = e.Message;
+            _window.SetClosable(App.CanClose);
         }
     }
 
     [ReactiveCommand]
     private async Task Cancel()
     {
+        if (IsSubmitting)
+        {
+            return;
+        }
+
         if (_envelope is not null)
         {
             await _reporter.CacheAsync(_envelope);

--- a/Sentry.CrashReporter/ViewModels/MainViewModel.cs
+++ b/Sentry.CrashReporter/ViewModels/MainViewModel.cs
@@ -22,9 +22,17 @@ public partial class MainViewModel : ReactiveObject, ILoadable
 
     public event EventHandler? IsExecutingChanged;
 
-    public MainViewModel(ICrashReporter? reporter = null)
+    public MainViewModel(ICrashReporter? reporter = null, IWindowService? windowService = null)
     {
         reporter ??= App.Services.GetRequiredService<ICrashReporter>();
+        windowService ??= App.Services.GetRequiredService<IWindowService>();
+        windowService.Closing += async () =>
+        {
+            if (Envelope is not null)
+            {
+                await reporter.CacheAsync(Envelope);
+            }
+        };
 
         this.WhenAnyValue(x => x.IsExecuting)
             .Subscribe(x => IsExecutingChanged?.Invoke(this, EventArgs.Empty));

--- a/Sentry.CrashReporter/Views/MainPage.cs
+++ b/Sentry.CrashReporter/Views/MainPage.cs
@@ -183,12 +183,12 @@ public sealed class MainPage : Page
                 Key = VirtualKey.Q,
                 Modifiers = VirtualKeyModifiers.Windows
             };
-            closeAccelerator.Invoked += (_, ev) =>
+            closeAccelerator.Invoked += async (_, ev) =>
             {
                 ev.Handled = true;
                 if (App.CanClose)
                 {
-                    App.Services.GetRequiredService<IWindowService>().Close();
+                    await App.Services.GetRequiredService<IWindowService>().RequestCloseAsync();
                 }
             };
             accelerators.Add(closeAccelerator);


### PR DESCRIPTION
Cache the envelope and minidump files under `cache_dir` when sending fails, or the submission is canceled, which basically corresponds to revoking user-consent in sentry-native/unreal.

<img width="1012" height="744" alt="image" src="https://github.com/user-attachments/assets/247f3eb1-7c95-4051-a39d-dde2afab5d01" />

Before cancel:
```
.sentry-native/
└── external/
    └── b8eb3e4c-a8e5-4932-c4f5-1c4ce46a383d.envelope
```

After cancel:
```
.sentry-native/
└── cache/
    ├── b8eb3e4c-a8e5-4932-c4f5-1c4ce46a383d.dmp
    └── b8eb3e4c-a8e5-4932-c4f5-1c4ce46a383d.envelope
```

See also:
- https://github.com/getsentry/sentry-native/issues/1688
- https://github.com/getsentry/sentry-native/pull/1698