### PR TITLE
chore(dependabot): Scope NuGet manifests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,17 @@ updates:
   commit-message:
     prefix: "chore(deps)"
 - package-ecosystem: nuget
-  directory: "/Sentry.CrashReporter"
+  directory: "/"
+  exclude-paths:
+    - "tests/**"
   schedule:
     interval: weekly
   commit-message:
     prefix: "chore(deps)"
 - package-ecosystem: nuget
   directory: "/tests"
+  exclude-paths:
+    - "Sentry.CrashReporter.RuntimeTests.Host/**"
   schedule:
     interval: weekly
   groups:


### PR DESCRIPTION
Point the production NuGet update job at the root manifest while excluding test manifests. Keep the test dependency job scoped to tests and exclude the Uno runtime test host so SDK updates stay production dependency updates.