### PR TITLE
chore(dependabot): Use test project directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,13 +13,12 @@ updates:
   commit-message:
     prefix: "chore(deps)"
 - package-ecosystem: nuget
-  directory: "/tests"
-  exclude-paths:
-    - "Sentry.CrashReporter.RuntimeTests.Host/**"
+  directories:
+    - "/tests/Sentry.CrashReporter.*Tests"
   schedule:
     interval: weekly
   groups:
-    test-dependencies:
+    tests:
       patterns:
         - "*"
   ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,9 @@ updates:
     prefix: "chore(deps)"
 - package-ecosystem: nuget
   directories:
-    - "/tests/Sentry.CrashReporter.*Tests"
+    - "/tests/Sentry.CrashReporter.Tests"
+    - "/tests/Sentry.CrashReporter.UITests"
+    - "/tests/Sentry.CrashReporter.RuntimeTests"
   schedule:
     interval: weekly
   groups:


### PR DESCRIPTION
Point the test NuGet update job at the matching test project directories so Dependabot discovers the test project manifests. Name the grouped test dependency updates `tests`.