### PR TITLE
test(deps): Migrate to AwesomeAssertions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,9 +24,6 @@ updates:
       patterns:
         - "*"
   ignore:
-    # https://fluentassertions.com/releases/#800
-    - dependency-name: "FluentAssertions"
-      versions: ["8.*"]
     # The NuGet updater can follow ProjectReferences out of /tests.
     - dependency-name: "Uno.Sdk"
   commit-message:

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
-    <PackageVersion Include="FluentAssertions" Version="7.2.2" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />

--- a/tests/Sentry.CrashReporter.Tests/GlobalUsings.cs
+++ b/tests/Sentry.CrashReporter.Tests/GlobalUsings.cs
@@ -1,4 +1,4 @@
-global using FluentAssertions;
+global using AwesomeAssertions;
 global using Moq;
 global using Moq.Protected;
 global using NUnit.Framework;

--- a/tests/Sentry.CrashReporter.Tests/Sentry.CrashReporter.Tests.csproj
+++ b/tests/Sentry.CrashReporter.Tests/Sentry.CrashReporter.Tests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions"/>
+        <PackageReference Include="AwesomeAssertions"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="Moq" />
         <PackageReference Include="NUnit"/>

--- a/tests/Sentry.CrashReporter.UITests/Sentry.CrashReporter.UITests.csproj
+++ b/tests/Sentry.CrashReporter.UITests/Sentry.CrashReporter.UITests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions"/>
+        <PackageReference Include="AwesomeAssertions"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="Newtonsoft.Json"/>
         <PackageReference Include="NUnit"/>


### PR DESCRIPTION
Replace FluentAssertions with AwesomeAssertions in the test projects and use the AwesomeAssertions namespace. Remove the stale FluentAssertions Dependabot ignore now that the package is no longer referenced.

See also:
- https://awesomeassertions.org/
- https://fluentassertions.com/releases/#800