### PR TITLE
chore: fix warnings

### DIFF
--- a/Sentry.CrashReporter/App.xaml.cs
+++ b/Sentry.CrashReporter/App.xaml.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Microsoft.Extensions.Http.Resilience;
 using Sentry.CrashReporter.Extensions;
@@ -56,6 +57,8 @@ public partial class App : Application
     protected IHost? Host { get; private set; }
     public static IServiceProvider Services { get; internal set; } = Ioc.Default;
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Uno startup uses reflection-based configuration and navigation APIs; the app registers concrete routes and roots this assembly for trimmed builds.")]
     protected async override void OnLaunched(LaunchActivatedEventArgs args)
     {
         // Load WinUI Resources

--- a/Sentry.CrashReporter/Controls/ErrorView.cs
+++ b/Sentry.CrashReporter/Controls/ErrorView.cs
@@ -10,7 +10,7 @@ public sealed class ErrorView : UserControl
 
     public static readonly DependencyProperty ErrorProperty = DependencyProperty.Register(
         nameof(Error),
-        typeof(Exception),
+        typeof(object),
         typeof(ErrorView),
         new PropertyMetadata(null, OnErrorChanged));
 

--- a/Sentry.CrashReporter/Controls/ErrorView.cs
+++ b/Sentry.CrashReporter/Controls/ErrorView.cs
@@ -16,7 +16,7 @@ public sealed class ErrorView : UserControl
 
     public Exception? Error
     {
-        get => (Exception?)GetValue(ErrorProperty);
+        get => GetValue(ErrorProperty) as Exception;
         set => SetValue(ErrorProperty, value);
     }
 

--- a/Sentry.CrashReporter/Sentry.CrashReporter.csproj
+++ b/Sentry.CrashReporter/Sentry.CrashReporter.csproj
@@ -40,6 +40,13 @@
 
     </PropertyGroup>
 
+    <PropertyGroup>
+        <!-- GitInfo -->
+        <GitRepositoryUrl>https://github.com/getsentry/sentry-desktop-crash-reporter</GitRepositoryUrl>
+        <!-- Use generated C# file instead of virtual ThisAssembly.Constants AdditionalFiles. -->
+        <UseTemplatedCode>true</UseTemplatedCode>
+    </PropertyGroup>
+
     <PropertyGroup Condition="'$(Configuration)'=='Debug' or '$(IsUiAutomationMappingEnabled)'=='True'">
         <IsUiAutomationMappingEnabled>True</IsUiAutomationMappingEnabled>
         <DefineConstants>$(DefineConstants);USE_UITESTS</DefineConstants>

--- a/tests/Sentry.CrashReporter.RuntimeTests/ErrorViewTests.cs
+++ b/tests/Sentry.CrashReporter.RuntimeTests/ErrorViewTests.cs
@@ -30,4 +30,17 @@ public class ErrorViewTests : RuntimeTestBase
         Assert.IsNotEmpty(exception.StackTrace);
         Assert.IsNotNull(view.FindFirstDescendant<TextBlock>(tb => tb.Text == exception.StackTrace));
     }
+
+    [TestMethod]
+    public void ErrorView_WithNonExceptionDependencyPropertyValue_ReturnsNullError()
+    {
+        // Arrange
+        var view = new ErrorView();
+
+        // Act
+        view.SetValue(ErrorView.ErrorProperty, "Something went wrong");
+
+        // Assert
+        Assert.IsNull(view.Error);
+    }
 }


### PR DESCRIPTION
Before:
```
0>------- Started building project: Sentry.CrashReporter
...
0>------- Finished building project: Sentry.CrashReporter. Succeeded: True. Errors: 0. Warnings: 12
Build completed in 00:00:10.987
```

After:
```
0>------- Started building project: Sentry.CrashReporter
...
0>------- Finished building project: Sentry.CrashReporter. Succeeded: True. Errors: 0. Warnings: 0
Build completed in 00:00:10.121

```