### PR TITLE
test(deps): bump Uno.UI.RuntimeTests.Engine to 2.0.0-dev.79

### DIFF
--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="MSTest.TestFramework" Version="3.11.0" />
     <PackageVersion Include="NUnit" Version="4.6.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="1.33.0-dev.11" />
+    <PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="2.0.0-dev.79" />
     <PackageVersion Include="Uno.UITest.Helpers" Version="1.1.0-dev.92" />
     <PackageVersion Include="WireMock.Net" Version="2.6.0" />
     <PackageVersion Include="Xamarin.UITest" Version="4.4.2" />


### PR DESCRIPTION
Not sure why Dependabot doesn't bump this, but hopefully it helps with the frequent Runtime Test CI failures...