### PR TITLE
feat: add configurable cache keep setting

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -116,6 +116,7 @@ settings into the sentry-native database directory.
     "WindowTitle": "My Crash Reporter",
     "WindowClosable": false,
     "HeaderText": "Something Went Wrong",
+    "CacheKeep": "Always",
     "LogoLight": "branding/logo-light.png",
     "LogoDark": "branding/logo-dark.png",
     "SystemAccentColor": "#4CAF50"
@@ -133,6 +134,7 @@ settings into the sentry-native database directory.
 | `HeaderDescription` | Description text below the header. Hidden when empty. |
 | `CancelButton` | Cancel button label. Set to empty string to hide the button. |
 | `SubmitButton` | Submit button label. |
+| `CacheKeep` | Initial cache mode when the user has not selected one. Supported values: `None`, `Offline`, `Always`. Defaults to `Offline`. |
 | `LogoLight` | Path to a custom logo image for light theme (relative to the binary or absolute). |
 | `LogoDark` | Path to a custom logo image for dark theme (relative to the binary or absolute). |
 | `SystemAccentColor` | Primary brand color (`#RRGGBB` or `#AARRGGBB`). |

--- a/Sentry.CrashReporter/App.xaml.cs
+++ b/Sentry.CrashReporter/App.xaml.cs
@@ -39,6 +39,10 @@ public partial class App : Application
         {
             services.AddSingleton<ICacheService, CacheService>();
         }
+        var envelopeDir = Path.GetDirectoryName(file?.Path);
+        var databaseDir = Path.GetDirectoryName(envelopeDir);
+        var config = AppConfig.Load(envelopeDir, databaseDir, AppContext.BaseDirectory);
+        services.AddSingleton<AppConfig>(config ?? new AppConfig());
         services.AddSingleton<IWindowService, WindowService>();
         services.AddSingleton<IClipboardService, ClipboardService>();
         services.AddSingleton<IFilePickerService, FilePickerService>();
@@ -121,9 +125,7 @@ public partial class App : Application
             );
         MainWindow = builder.Window;
 
-        var envelopeDir = Path.GetDirectoryName(Services.GetService<IStorageFile>()?.Path);
-        var databaseDir = Path.GetDirectoryName(envelopeDir);
-        AppConfig.Load(envelopeDir, databaseDir, AppContext.BaseDirectory)?.Apply(Resources);
+        Services.GetRequiredService<AppConfig>().Apply(Resources);
 
         MainWindow.Title = (Resources["WindowTitle"] as string)!;
         MainWindow.Resize(900, 600);

--- a/Sentry.CrashReporter/Models/AppConfig.cs
+++ b/Sentry.CrashReporter/Models/AppConfig.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Sentry.CrashReporter.Extensions;
+using Sentry.CrashReporter.Services;
 using Path = System.IO.Path;
 
 namespace Sentry.CrashReporter.Models;
@@ -29,6 +30,8 @@ public record AppConfig
     public bool? WindowClosable { get; init; }
     public string? LogoLight { get; init; }
     public string? LogoDark { get; init; }
+    [JsonConverter(typeof(JsonStringEnumConverter<CacheKeep>))]
+    public CacheKeep? CacheKeep { get; init; }
 
     private const string FileName = "appsettings.json";
 

--- a/Sentry.CrashReporter/Sentry.CrashReporter.csproj
+++ b/Sentry.CrashReporter/Sentry.CrashReporter.csproj
@@ -52,16 +52,19 @@
         <DefineConstants>$(DefineConstants);USE_UITESTS</DefineConstants>
     </PropertyGroup>
 
-    <ItemGroup Condition="$(TargetFramework.Contains('browserwasm'))">
-        <Content Include="../tests/data/inproc.envelope" />
-    </ItemGroup>
-
-    <ItemGroup Condition="$(TargetFramework.Contains('desktop'))">
+    <ItemGroup>
         <Content Include="../tests/data/*.envelope">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <CopyToPublishDirectory>Never</CopyToPublishDirectory>
             <Link>%(Filename)%(Extension)</Link>
             <TargetPath>%(Filename)%(Extension)</TargetPath>
+        </Content>
+        <Content Update="../tests/data/inproc.envelope" Condition="$(TargetFramework.Contains('browserwasm'))">
+            <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        </Content>
+        <Content Include="appsettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToPublishDirectory>Never</CopyToPublishDirectory>
         </Content>
     </ItemGroup>
 
@@ -90,7 +93,6 @@
         <!-- Required for the main assembly when trimming is enabled -->
         <TrimmerRootAssembly Include="Sentry.CrashReporter" />
     </ItemGroup>
-
 
     <ItemGroup>
         <Content Include="Assets\AppLogo.png" />

--- a/Sentry.CrashReporter/Services/CacheService.cs
+++ b/Sentry.CrashReporter/Services/CacheService.cs
@@ -7,66 +7,77 @@ public enum CacheKeep
     Always = 2
 }
 
-public interface ICacheService
+internal static class CacheKeepExtensions
 {
-    CacheKeep CacheKeep { get; set; }
-}
-
-public class CacheService : ICacheService
-{
-    private const string Key = "cache_keep";
-    private CacheKeep _cacheKeep;
-
-    public CacheService()
-    {
-        _cacheKeep = Load();
-    }
-
-    public CacheKeep CacheKeep
-    {
-        get => _cacheKeep;
-        set
-        {
-            value = Normalize(value);
-            if (_cacheKeep == value)
-            {
-                return;
-            }
-
-            _cacheKeep = value;
-            Save(value);
-        }
-    }
-
-    private static CacheKeep Load()
-    {
-        var values = ApplicationData.Current.LocalSettings.Values;
-        if (values.TryGetValue(Key, out var value) && value is int raw)
-        {
-            return Normalize((CacheKeep)raw);
-        }
-
-        return CacheKeep.Offline;
-    }
-
-    private static void Save(CacheKeep value)
-    {
-        ApplicationData.Current.LocalSettings.Values[Key] = (int)value;
-    }
-
-    internal static CacheKeep Normalize(CacheKeep value) =>
+    public static CacheKeep Normalize(this CacheKeep value) =>
         value is CacheKeep.None or CacheKeep.Offline or CacheKeep.Always
             ? value
             : CacheKeep.Offline;
 }
 
-internal class MemoryCacheService(CacheKeep cacheKeep = CacheKeep.Offline) : ICacheService
+public interface ICacheService
 {
-    private CacheKeep _cacheKeep = CacheService.Normalize(cacheKeep);
+    CacheKeep? CacheKeep { get; set; }
+}
 
-    public CacheKeep CacheKeep
+public class CacheService : ICacheService
+{
+    private const string Key = "cache_keep";
+
+    private readonly IDictionary<string, object?>? _settings;
+    private CacheKeep? _cacheKeep;
+
+    public CacheService(IDictionary<string, object?>? settings = null)
+    {
+        _settings = settings ?? ApplicationData.Current?.LocalSettings?.Values;
+        _cacheKeep = Load(_settings);
+    }
+
+    public CacheKeep? CacheKeep
     {
         get => _cacheKeep;
-        set => _cacheKeep = CacheService.Normalize(value);
+        set
+        {
+            _cacheKeep = value.HasValue ? value.Value.Normalize() : null;
+            if (_settings is null)
+            {
+                return;
+            }
+
+            if (_cacheKeep.HasValue)
+            {
+                _settings[Key] = (int)_cacheKeep.Value;
+            }
+            else
+            {
+                _settings.Remove(Key);
+            }
+        }
+    }
+
+    private static CacheKeep? Load(IDictionary<string, object?>? settings)
+    {
+        if (settings is not null && settings.TryGetValue(Key, out var value) && value is int raw)
+        {
+            return ((CacheKeep)raw).Normalize();
+        }
+
+        return null;
+    }
+}
+
+internal class MemoryCacheService(CacheKeep? cacheKeep = null) : ICacheService
+{
+    private CacheKeep? _cacheKeep = cacheKeep is { } value
+        ? value.Normalize()
+        : null;
+
+    public CacheKeep? CacheKeep
+    {
+        get => _cacheKeep;
+        set
+        {
+            _cacheKeep = value.HasValue ? value.Value.Normalize() : null;
+        }
     }
 }

--- a/Sentry.CrashReporter/Services/CrashReporter.cs
+++ b/Sentry.CrashReporter/Services/CrashReporter.cs
@@ -17,11 +17,13 @@ public interface ICrashReporter
 public class CrashReporter(
     IStorageFile? file = null,
     ISentryClient? client = null,
-    ICacheService? cache = null) : ICrashReporter
+    ICacheService? cache = null,
+    AppConfig? config = null) : ICrashReporter
 {
     private readonly IStorageFile? _file = file ?? App.Services.GetService<IStorageFile>();
     private readonly ISentryClient _client = client ?? App.Services.GetRequiredService<ISentryClient>();
     private readonly ICacheService _cache = cache ?? App.Services.GetRequiredService<ICacheService>();
+    private readonly AppConfig _config = config ?? App.Services.GetRequiredService<AppConfig>();
     private Envelope? _submittingEnvelope;
     private readonly HashSet<Envelope> _submittedEnvelopes = [];
     private Feedback? _feedback = ResolveFeedback();
@@ -51,7 +53,7 @@ public class CrashReporter(
         try
         {
             await _client.SubmitEnvelopeAsync(dsn, envelope, cancellationToken);
-            var cachedEnvelopePath = await CacheAsync(envelope, _cache.CacheKeep, cancellationToken);
+            var cachedEnvelopePath = await CacheAsync(envelope, EffectiveCacheKeep, cancellationToken);
             _submittedEnvelopes.Add(envelope);
             DeleteEnvelope(envelope, cachedEnvelopePath);
         }
@@ -110,7 +112,7 @@ public class CrashReporter(
             {
                 return;
             }
-            if (_cache.CacheKeep == CacheKeep.None)
+            if (EffectiveCacheKeep == CacheKeep.None)
             {
                 DeleteEnvelope(envelope);
                 return;
@@ -154,6 +156,8 @@ public class CrashReporter(
             this.Log().LogWarning(e, "Failed to cache crash envelope.");
         }
     }
+
+    private CacheKeep EffectiveCacheKeep => (_cache.CacheKeep ?? _config.CacheKeep ?? CacheKeep.Offline).Normalize();
 
     private async Task<string?> CacheAsync(Envelope envelope, CacheKeep cacheKeep, CancellationToken cancellationToken)
     {

--- a/Sentry.CrashReporter/Services/CrashReporter.cs
+++ b/Sentry.CrashReporter/Services/CrashReporter.cs
@@ -8,6 +8,7 @@ public record Feedback(string? Name, string? Email, string Message);
 public interface ICrashReporter
 {
     Feedback? Feedback { get; }
+    CacheKeep EffectiveCacheKeep { get; }
     public Task<Envelope?> LoadAsync(CancellationToken cancellationToken = default);
     public Task CacheAsync(Envelope envelope, CancellationToken cancellationToken = default);
     public Task SubmitAsync(Envelope envelope, CancellationToken cancellationToken = default);
@@ -157,7 +158,7 @@ public class CrashReporter(
         }
     }
 
-    private CacheKeep EffectiveCacheKeep => (_cache.CacheKeep ?? _config.CacheKeep ?? CacheKeep.Offline).Normalize();
+    public CacheKeep EffectiveCacheKeep => (_cache.CacheKeep ?? _config.CacheKeep ?? CacheKeep.Offline).Normalize();
 
     private async Task<string?> CacheAsync(Envelope envelope, CacheKeep cacheKeep, CancellationToken cancellationToken)
     {

--- a/Sentry.CrashReporter/ViewModels/FooterViewModel.cs
+++ b/Sentry.CrashReporter/ViewModels/FooterViewModel.cs
@@ -19,6 +19,7 @@ public partial class FooterViewModel : ReactiveObject
     private readonly IWindowService _window;
     private readonly ICacheService _cache;
     private readonly IClipboardService _clipboard;
+    private readonly AppConfig _config;
     [Reactive] private Envelope? _envelope;
     [ObservableAsProperty] private string? _dsn = string.Empty;
     [ObservableAsProperty] private string? _eventId = string.Empty;
@@ -28,6 +29,7 @@ public partial class FooterViewModel : ReactiveObject
     [ObservableAsProperty] private string? _cacheDirectory = string.Empty;
     [ObservableAsProperty] private bool _canCache;
     [Reactive] private CacheKeep _cacheKeep;
+    [Reactive] private bool _canResetCacheKeep;
     [Reactive] private int _cacheKeepIndex;
     [ObservableAsProperty] private bool _isSubmitting;
     private readonly IObservable<bool> _canSubmit;
@@ -36,20 +38,24 @@ public partial class FooterViewModel : ReactiveObject
 
     public ReactiveCommand<Unit, string?> CopyEventIdCommand { get; }
     public ReactiveCommand<CacheKeep, Unit> SetCacheKeepCommand { get; }
+    public ReactiveCommand<Unit, Unit> ResetCacheKeepCommand { get; }
     public ReactiveCommand<Unit, Unit> OpenCacheDirectoryCommand { get; }
 
     public FooterViewModel(
         ICrashReporter? reporter = null,
         IWindowService? windowService = null,
         ICacheService? cache = null,
-        IClipboardService? clipboardService = null)
+        IClipboardService? clipboardService = null,
+        AppConfig? config = null)
     {
         _reporter = reporter ?? App.Services.GetRequiredService<ICrashReporter>();
         _window = windowService ?? App.Services.GetRequiredService<IWindowService>();
         _cache = cache ?? App.Services.GetRequiredService<ICacheService>();
         _clipboard = clipboardService ?? App.Services.GetRequiredService<IClipboardService>();
+        _config = config ?? App.Services.GetRequiredService<AppConfig>();
 
-        CacheKeep = _cache.CacheKeep;
+        CacheKeep = EffectiveCacheKeep;
+        CanResetCacheKeep = _cache.CacheKeep is not null;
         CacheKeepIndex = CacheKeepToIndex(CacheKeep);
 
         _dsnHelper = this.WhenAnyValue(x => x.Envelope,  e => e?.TryGetDsn())
@@ -83,7 +89,6 @@ public partial class FooterViewModel : ReactiveObject
         this.WhenAnyValue(x => x.CacheKeep)
             .Subscribe(cacheKeep =>
             {
-                _cache.CacheKeep = cacheKeep;
                 var cacheKeepIndex = CacheKeepToIndex(cacheKeep);
                 if (CacheKeepIndex != cacheKeepIndex)
                 {
@@ -92,15 +97,10 @@ public partial class FooterViewModel : ReactiveObject
             });
 
         this.WhenAnyValue(x => x.CacheKeepIndex)
+            .Skip(1)
             .Where(index => index >= 0)
             .Select(IndexToCacheKeep)
-            .Subscribe(cacheKeep =>
-            {
-                if (CacheKeep != cacheKeep)
-                {
-                    CacheKeep = cacheKeep;
-                }
-            });
+            .Subscribe(SetCacheKeep);
 
         _canSubmit = this.WhenAnyValue(x => x.Dsn)
             .Select(dsn => !string.IsNullOrWhiteSpace(dsn));
@@ -108,9 +108,11 @@ public partial class FooterViewModel : ReactiveObject
             .Select(eventId => !string.IsNullOrWhiteSpace(eventId));
         var canOpenCacheDirectory = this.WhenAnyValue(x => x.CacheDirectory)
             .Select(cacheDirectory => !string.IsNullOrWhiteSpace(cacheDirectory));
+        var canResetCacheKeep = this.WhenAnyValue(x => x.CanResetCacheKeep);
 
         CopyEventIdCommand = ReactiveCommand.Create(CopyEventId, canCopyEventId);
-        SetCacheKeepCommand = ReactiveCommand.Create<CacheKeep>(cacheKeep => CacheKeep = cacheKeep);
+        SetCacheKeepCommand = ReactiveCommand.Create<CacheKeep>(SetCacheKeep);
+        ResetCacheKeepCommand = ReactiveCommand.Create(ResetCacheKeep, canResetCacheKeep);
         OpenCacheDirectoryCommand = ReactiveCommand.CreateFromTask(OpenCacheDirectory, canOpenCacheDirectory);
 
         _isSubmittingHelper = this.WhenAnyObservable(x => x.SubmitCommand.IsExecuting)
@@ -153,6 +155,24 @@ public partial class FooterViewModel : ReactiveObject
             2 => CacheKeep.Always,
             _ => CacheKeep.Offline
         };
+
+    private CacheKeep EffectiveCacheKeep =>
+        (_cache.CacheKeep ?? _config.CacheKeep ?? Sentry.CrashReporter.Services.CacheKeep.Offline).Normalize();
+
+    private void SetCacheKeep(CacheKeep cacheKeep)
+    {
+        var hasOverride = _cache.CacheKeep is not null || cacheKeep != EffectiveCacheKeep;
+        _cache.CacheKeep = hasOverride ? cacheKeep : null;
+        CanResetCacheKeep = hasOverride;
+        CacheKeep = cacheKeep;
+    }
+
+    private void ResetCacheKeep()
+    {
+        _cache.CacheKeep = null;
+        CanResetCacheKeep = _cache.CacheKeep is not null;
+        CacheKeep = EffectiveCacheKeep;
+    }
 
     private string? CopyEventId()
     {

--- a/Sentry.CrashReporter/ViewModels/FooterViewModel.cs
+++ b/Sentry.CrashReporter/ViewModels/FooterViewModel.cs
@@ -19,7 +19,6 @@ public partial class FooterViewModel : ReactiveObject
     private readonly IWindowService _window;
     private readonly ICacheService _cache;
     private readonly IClipboardService _clipboard;
-    private readonly AppConfig _config;
     [Reactive] private Envelope? _envelope;
     [ObservableAsProperty] private string? _dsn = string.Empty;
     [ObservableAsProperty] private string? _eventId = string.Empty;
@@ -45,16 +44,14 @@ public partial class FooterViewModel : ReactiveObject
         ICrashReporter? reporter = null,
         IWindowService? windowService = null,
         ICacheService? cache = null,
-        IClipboardService? clipboardService = null,
-        AppConfig? config = null)
+        IClipboardService? clipboardService = null)
     {
         _reporter = reporter ?? App.Services.GetRequiredService<ICrashReporter>();
         _window = windowService ?? App.Services.GetRequiredService<IWindowService>();
         _cache = cache ?? App.Services.GetRequiredService<ICacheService>();
         _clipboard = clipboardService ?? App.Services.GetRequiredService<IClipboardService>();
-        _config = config ?? App.Services.GetRequiredService<AppConfig>();
 
-        CacheKeep = EffectiveCacheKeep;
+        CacheKeep = _reporter.EffectiveCacheKeep;
         CanResetCacheKeep = _cache.CacheKeep is not null;
         CacheKeepIndex = CacheKeepToIndex(CacheKeep);
 
@@ -156,12 +153,9 @@ public partial class FooterViewModel : ReactiveObject
             _ => CacheKeep.Offline
         };
 
-    private CacheKeep EffectiveCacheKeep =>
-        (_cache.CacheKeep ?? _config.CacheKeep ?? Sentry.CrashReporter.Services.CacheKeep.Offline).Normalize();
-
     private void SetCacheKeep(CacheKeep cacheKeep)
     {
-        var hasOverride = _cache.CacheKeep is not null || cacheKeep != EffectiveCacheKeep;
+        var hasOverride = _cache.CacheKeep is not null || cacheKeep != _reporter.EffectiveCacheKeep;
         _cache.CacheKeep = hasOverride ? cacheKeep : null;
         CanResetCacheKeep = hasOverride;
         CacheKeep = cacheKeep;
@@ -171,7 +165,7 @@ public partial class FooterViewModel : ReactiveObject
     {
         _cache.CacheKeep = null;
         CanResetCacheKeep = _cache.CacheKeep is not null;
-        CacheKeep = EffectiveCacheKeep;
+        CacheKeep = _reporter.EffectiveCacheKeep;
     }
 
     private string? CopyEventId()

--- a/Sentry.CrashReporter/Views/FooterView.cs
+++ b/Sentry.CrashReporter/Views/FooterView.cs
@@ -72,7 +72,7 @@ public sealed class FooterView : ReactiveUserControl<FooterViewModel>
             .Spacing(8)
             .Visibility(x => x.Binding(() => vm.CanCache)
                 .Convert(canCache => canCache ? Visibility.Visible : Visibility.Collapsed));
-        cacheSection.Children.Add(BuildSectionHeader("Cache", BuildOpenCacheDirectoryButton(vm, close)));
+        cacheSection.Children.Add(BuildCacheSectionHeader(vm, close));
         cacheSection.Children.Add(BuildCacheSegmented(vm, close));
 
         return new StackPanel()
@@ -96,6 +96,24 @@ public sealed class FooterView : ReactiveUserControl<FooterViewModel>
                     .VerticalAlignment(VerticalAlignment.Center)
                     .Grid(0),
                 action.Grid(1));
+    }
+
+    private static FrameworkElement BuildCacheSectionHeader(FooterViewModel vm, Action close)
+    {
+        return new Grid()
+            .ColumnSpacing(6)
+            .ColumnDefinitions("Auto,Auto,*,Auto")
+            .Children(
+                new TextBlock()
+                    .Text("Cache")
+                    .FontWeight(Microsoft.UI.Text.FontWeights.SemiBold)
+                    .VerticalAlignment(VerticalAlignment.Center)
+                    .Grid(0),
+                BuildResetCacheKeepButton(vm)
+                    .Grid(1)
+                    .Visibility(x => x.Binding(() => vm.CanResetCacheKeep).Convert(ToVisibility)),
+                BuildOpenCacheDirectoryButton(vm, close)
+                    .Grid(3));
     }
 
     private static FrameworkElement BuildEventIdText(FooterViewModel vm)
@@ -212,6 +230,26 @@ public sealed class FooterView : ReactiveUserControl<FooterViewModel>
         segmented.AddHandler(UIElement.TappedEvent, new TappedEventHandler((_, _) => close()), true);
         return segmented;
     }
+
+    private static Button BuildResetCacheKeepButton(FooterViewModel vm)
+    {
+        var button = new Button()
+            .Content(new FontAwesomeIcon(FA.ArrowRotateLeft).FontSize(12))
+            .Width(28)
+            .Height(28)
+            .MinWidth(0)
+            .MinHeight(0)
+            .IsTabStop(false)
+            .Padding(0)
+            .Background(Colors.Transparent)
+            .BorderBrush(Colors.Transparent)
+            .Command(x => x.Binding(() => vm.ResetCacheKeepCommand))
+            .ToolTip("Reset");
+        return button;
+    }
+
+    private static Visibility ToVisibility(bool visible) =>
+        visible ? Visibility.Visible : Visibility.Collapsed;
 
     private static FrameworkElement BuildStatusLabelSafe(FooterViewModel vm, FooterStatus status)
     {

--- a/Sentry.CrashReporter/appsettings.json
+++ b/Sentry.CrashReporter/appsettings.json
@@ -1,5 +1,5 @@
 {
   "AppConfig": {
-    "Environment": "Production"
+    "CacheKeep": "Always"
   }
 }

--- a/tests/Sentry.CrashReporter.RuntimeTests/RuntimeTestBase.cs
+++ b/tests/Sentry.CrashReporter.RuntimeTests/RuntimeTestBase.cs
@@ -36,16 +36,19 @@ public class RuntimeTestBase
 
     protected static MockRuntime MockRuntime(Envelope? envelope = null)
     {
+        var appConfig = new AppConfig();
         var mockReporter = new Mock<ICrashReporter>();
         mockReporter.Setup(x => x.LoadAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult(envelope));
         var mockWindow = new Mock<IWindowService>();
         var cacheKeep = new MemoryCacheService();
+        mockReporter.Setup(x => x.EffectiveCacheKeep)
+            .Returns(() => (cacheKeep.CacheKeep ?? appConfig.CacheKeep ?? CacheKeep.Offline).Normalize());
         var mockClipboard = new Mock<IClipboardService>();
         var mockFilePicker = new Mock<IFilePickerService>();
 
         var services = new ServiceCollection();
-        services.AddSingleton(new AppConfig());
+        services.AddSingleton(appConfig);
         services.AddSingleton(mockReporter.Object);
         services.AddSingleton(mockWindow.Object);
         services.AddSingleton<ICacheService>(cacheKeep);

--- a/tests/Sentry.CrashReporter.RuntimeTests/RuntimeTestBase.cs
+++ b/tests/Sentry.CrashReporter.RuntimeTests/RuntimeTestBase.cs
@@ -45,6 +45,7 @@ public class RuntimeTestBase
         var mockFilePicker = new Mock<IFilePickerService>();
 
         var services = new ServiceCollection();
+        services.AddSingleton(new AppConfig());
         services.AddSingleton(mockReporter.Object);
         services.AddSingleton(mockWindow.Object);
         services.AddSingleton<ICacheService>(cacheKeep);

--- a/tests/Sentry.CrashReporter.Tests/AppConfigTests.cs
+++ b/tests/Sentry.CrashReporter.Tests/AppConfigTests.cs
@@ -159,6 +159,23 @@ public class AppConfigTests
     }
 
     [Test]
+    public void Load_CacheKeep_ReturnsValue()
+    {
+        var dir = WriteConfig("""
+        {
+          "AppConfig": {
+            "CacheKeep": "Always"
+          }
+        }
+        """);
+
+        var result = AppConfig.Load(dir);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.CacheKeep, Is.EqualTo(CacheKeep.Always));
+    }
+
+    [Test]
     public void Load_EmptyCancelButtonText_ReturnsEmptyString()
     {
         var dir = WriteConfig("""

--- a/tests/Sentry.CrashReporter.Tests/CacheServiceTests.cs
+++ b/tests/Sentry.CrashReporter.Tests/CacheServiceTests.cs
@@ -1,7 +1,105 @@
 namespace Sentry.CrashReporter.Tests;
 
+using Microsoft.Extensions.DependencyInjection;
+
 public class CacheServiceTests
 {
+    [Test]
+    public void CacheKeep_IsNullWhenUnset()
+    {
+        // Act
+        var service = new CacheService(new Dictionary<string, object?>());
+
+        // Assert
+        service.CacheKeep.Should().BeNull();
+    }
+
+    [Test]
+    public void CacheKeep_IsNullWhenConstructedByDependencyInjection()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton<ICacheService, CacheService>();
+        var serviceProvider = services.BuildServiceProvider();
+
+        // Act
+        var service = serviceProvider.GetRequiredService<ICacheService>();
+
+        // Assert
+        service.CacheKeep.Should().BeNull();
+    }
+
+    [Test]
+    public void CacheKeep_LoadsPersistedValue()
+    {
+        // Arrange
+        var settings = new Dictionary<string, object?> { ["cache_keep"] = (int)CacheKeep.None };
+
+        // Act
+        var service = new CacheService(settings);
+
+        // Assert
+        service.CacheKeep.Should().Be(CacheKeep.None);
+    }
+
+    [Test]
+    public void CacheKeep_LoadsPersistedDefaultValue()
+    {
+        // Arrange
+        var settings = new Dictionary<string, object?> { ["cache_keep"] = (int)CacheKeep.Always };
+
+        // Act
+        var service = new CacheService(settings);
+
+        // Assert
+        service.CacheKeep.Should().Be(CacheKeep.Always);
+        settings["cache_keep"].Should().Be((int)CacheKeep.Always);
+    }
+
+    [Test]
+    public void CacheKeep_SavesChanges()
+    {
+        // Arrange
+        var settings = new Dictionary<string, object?>();
+        var service = new CacheService(settings);
+
+        // Act
+        service.CacheKeep = CacheKeep.Always;
+
+        // Assert
+        settings["cache_keep"].Should().Be((int)CacheKeep.Always);
+    }
+
+    [Test]
+    public void CacheKeep_SavesOffline()
+    {
+        // Arrange
+        var settings = new Dictionary<string, object?> { ["cache_keep"] = (int)CacheKeep.Always };
+        var service = new CacheService(settings);
+
+        // Act
+        service.CacheKeep = CacheKeep.Offline;
+
+        // Assert
+        service.CacheKeep.Should().Be(CacheKeep.Offline);
+        settings["cache_keep"].Should().Be((int)CacheKeep.Offline);
+    }
+
+    [Test]
+    public void CacheKeep_SettingNullRemovesPersistedValue()
+    {
+        // Arrange
+        var settings = new Dictionary<string, object?> { ["cache_keep"] = (int)CacheKeep.Always };
+        var service = new CacheService(settings);
+
+        // Act
+        service.CacheKeep = null;
+
+        // Assert
+        service.CacheKeep.Should().BeNull();
+        settings.Should().NotContainKey("cache_keep");
+    }
+
     [Test]
     public void MemoryCacheKeep_RoundTrips()
     {

--- a/tests/Sentry.CrashReporter.Tests/CrashReporterTests.cs
+++ b/tests/Sentry.CrashReporter.Tests/CrashReporterTests.cs
@@ -9,6 +9,7 @@ public class CrashReporterTests
     public void SetUp()
     {
         var services = new ServiceCollection();
+        services.AddSingleton(new AppConfig());
         services.AddSingleton<ICacheService>(new MemoryCacheService());
         App.Services = services.BuildServiceProvider();
     }

--- a/tests/Sentry.CrashReporter.Tests/FooterViewModelTests.cs
+++ b/tests/Sentry.CrashReporter.Tests/FooterViewModelTests.cs
@@ -21,7 +21,7 @@ public class FooterViewModelTests
     public void Defaults()
     {
         // Arrange
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter();
         var mockWindow = new Mock<IWindowService>();
 
         // Act
@@ -49,7 +49,7 @@ public class FooterViewModelTests
             },
             new List<EnvelopeItem>()
         );
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter();
         var mockWindow = new Mock<IWindowService>();
 
         // Act
@@ -91,7 +91,7 @@ public class FooterViewModelTests
                     [0x01])
             ]
         );
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter();
         var mockWindow = new Mock<IWindowService>();
 
         // Act
@@ -112,7 +112,7 @@ public class FooterViewModelTests
     {
         // Arrange
         var cacheKeep = new MemoryCacheService(CacheKeep.Always);
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter(cacheKeep);
         var mockWindow = new Mock<IWindowService>();
 
         // Act
@@ -136,7 +136,7 @@ public class FooterViewModelTests
     {
         // Arrange
         var cacheKeep = new MemoryCacheService(CacheKeep.Always);
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter(cacheKeep);
         var mockWindow = new Mock<IWindowService>();
 
         // Act
@@ -152,7 +152,7 @@ public class FooterViewModelTests
     {
         // Arrange
         var cacheKeep = new MemoryCacheService(CacheKeep.Offline);
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter(cacheKeep);
         var mockWindow = new Mock<IWindowService>();
 
         // Act
@@ -168,7 +168,7 @@ public class FooterViewModelTests
     {
         // Arrange
         var cacheKeep = new MemoryCacheService(CacheKeep.Always);
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter(cacheKeep);
         var mockWindow = new Mock<IWindowService>();
         var viewModel = new FooterViewModel(mockReporter.Object, mockWindow.Object, cacheKeep);
 
@@ -196,7 +196,7 @@ public class FooterViewModelTests
             new List<EnvelopeItem>()
         );
         var cacheKeep = new MemoryCacheService(CacheKeep.Offline);
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter(cacheKeep);
         var mockWindow = new Mock<IWindowService>();
         var viewModel = new FooterViewModel(mockReporter.Object, mockWindow.Object, cacheKeep)
         {
@@ -227,7 +227,7 @@ public class FooterViewModelTests
             new List<EnvelopeItem>()
         );
         var cacheKeep = new MemoryCacheService(CacheKeep.Offline);
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter(cacheKeep);
         var mockWindow = new Mock<IWindowService>();
         var viewModel = new FooterViewModel(mockReporter.Object, mockWindow.Object, cacheKeep)
         {
@@ -263,7 +263,7 @@ public class FooterViewModelTests
             },
             new List<EnvelopeItem>()
         );
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter();
         var mockWindow = new Mock<IWindowService>();
         var mockClipboard = new Mock<IClipboardService>();
         var viewModel = new FooterViewModel(mockReporter.Object, mockWindow.Object, clipboardService: mockClipboard.Object)
@@ -287,7 +287,7 @@ public class FooterViewModelTests
             new JsonObject { ["dsn"] = "https://foo@bar.com/123" },
             new List<EnvelopeItem>()
         );
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter();
         var tcs = new TaskCompletionSource<object?>();
         mockReporter.Setup(x => x.SubmitAsync(envelope, It.IsAny<CancellationToken>()))
             .Returns(tcs.Task);
@@ -318,7 +318,7 @@ public class FooterViewModelTests
             new JsonObject { ["dsn"] = "https://foo@bar.com/123" },
             new List<EnvelopeItem>()
         );
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter();
         mockReporter.Setup(x => x.SubmitAsync(It.IsAny<Envelope>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("Failure"));
         var mockWindow = new Mock<IWindowService>();
@@ -341,7 +341,7 @@ public class FooterViewModelTests
     public async Task CannotSubmit()
     {
         // Arrange
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter();
         var mockWindow = new Mock<IWindowService>();
 
         // Act
@@ -360,7 +360,7 @@ public class FooterViewModelTests
             new JsonObject { ["dsn"] = "https://foo@bar.com/123" },
             new List<EnvelopeItem>()
         );
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter();
         var mockWindow = new Mock<IWindowService>();
 
         // Act
@@ -382,7 +382,7 @@ public class FooterViewModelTests
             new JsonObject { ["dsn"] = "https://foo@bar.com/123" },
             new List<EnvelopeItem>()
         );
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter();
         var mockWindow = new Mock<IWindowService>();
 
         var viewModel = new FooterViewModel(mockReporter.Object, mockWindow.Object)
@@ -407,7 +407,7 @@ public class FooterViewModelTests
             new JsonObject { ["dsn"] = "https://foo@bar.com/123" },
             new List<EnvelopeItem>()
         );
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter();
         var tcs = new TaskCompletionSource<object?>();
         mockReporter.Setup(x => x.SubmitAsync(envelope, It.IsAny<CancellationToken>()))
             .Returns(tcs.Task);
@@ -439,7 +439,7 @@ public class FooterViewModelTests
             new JsonObject { ["dsn"] = "https://foo@bar.com/123" },
             new List<EnvelopeItem>()
         );
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter();
         mockReporter.Setup(x => x.SubmitAsync(envelope, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("Failure"));
         var mockWindow = new Mock<IWindowService>();
@@ -463,7 +463,7 @@ public class FooterViewModelTests
     public async Task Cancel_ClosesWindow()
     {
         // Arrange
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter();
         var mockWindow = new Mock<IWindowService>();
         var viewModel = new FooterViewModel(mockReporter.Object, mockWindow.Object);
 
@@ -484,7 +484,7 @@ public class FooterViewModelTests
             new JsonObject { ["dsn"] = "https://foo@bar.com/123" },
             new List<EnvelopeItem>()
         );
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter();
         var mockWindow = new Mock<IWindowService>();
         var viewModel = new FooterViewModel(mockReporter.Object, mockWindow.Object)
         {
@@ -508,7 +508,7 @@ public class FooterViewModelTests
             new JsonObject { ["dsn"] = "https://foo@bar.com/123" },
             new List<EnvelopeItem>()
         );
-        var mockReporter = new Mock<ICrashReporter>();
+        var mockReporter = MockReporter();
         var tcs = new TaskCompletionSource<object?>();
         mockReporter.Setup(x => x.SubmitAsync(envelope, It.IsAny<CancellationToken>()))
             .Returns(tcs.Task);
@@ -532,5 +532,16 @@ public class FooterViewModelTests
         // Cleanup
         tcs.SetResult(null);
         await submitTask;
+    }
+
+    private static Mock<ICrashReporter> MockReporter(ICacheService? cache = null, AppConfig? config = null)
+    {
+        cache ??= new MemoryCacheService();
+        config ??= new AppConfig();
+
+        var mockReporter = new Mock<ICrashReporter>();
+        mockReporter.Setup(x => x.EffectiveCacheKeep)
+            .Returns(() => (cache.CacheKeep ?? config.CacheKeep ?? CacheKeep.Offline).Normalize());
+        return mockReporter;
     }
 }

--- a/tests/Sentry.CrashReporter.Tests/FooterViewModelTests.cs
+++ b/tests/Sentry.CrashReporter.Tests/FooterViewModelTests.cs
@@ -11,6 +11,7 @@ public class FooterViewModelTests
     {
         var clipboard = new Mock<IClipboardService>();
         var services = new ServiceCollection();
+        services.AddSingleton(new AppConfig());
         services.AddSingleton<ICacheService>(new MemoryCacheService());
         services.AddSingleton<IClipboardService>(clipboard.Object);
         App.Services = services.BuildServiceProvider();
@@ -107,7 +108,7 @@ public class FooterViewModelTests
     }
 
     [Test]
-    public void CacheKeep_LoadsAndPersistsSelection()
+    public async Task CacheKeep_LoadsAndPersistsSelection()
     {
         // Arrange
         var cacheKeep = new MemoryCacheService(CacheKeep.Always);
@@ -123,11 +124,62 @@ public class FooterViewModelTests
         Assert.That(cacheKeep.CacheKeep, Is.EqualTo(CacheKeep.Always));
 
         // Act
-        viewModel.CacheKeep = CacheKeep.None;
+        await viewModel.SetCacheKeepCommand.Execute(CacheKeep.None);
 
         // Assert
         Assert.That(viewModel.CacheKeepIndex, Is.EqualTo(0));
         Assert.That(cacheKeep.CacheKeep, Is.EqualTo(CacheKeep.None));
+    }
+
+    [Test]
+    public void CacheKeepOverride_DifferentThanDefault_CanReset()
+    {
+        // Arrange
+        var cacheKeep = new MemoryCacheService(CacheKeep.Always);
+        var mockReporter = new Mock<ICrashReporter>();
+        var mockWindow = new Mock<IWindowService>();
+
+        // Act
+        var viewModel = new FooterViewModel(mockReporter.Object, mockWindow.Object, cacheKeep);
+
+        // Assert
+        Assert.That(viewModel.CacheKeep, Is.EqualTo(CacheKeep.Always));
+        Assert.That(viewModel.CanResetCacheKeep, Is.True);
+    }
+
+    [Test]
+    public void CacheKeepOverride_SameAsDefault_CanReset()
+    {
+        // Arrange
+        var cacheKeep = new MemoryCacheService(CacheKeep.Offline);
+        var mockReporter = new Mock<ICrashReporter>();
+        var mockWindow = new Mock<IWindowService>();
+
+        // Act
+        var viewModel = new FooterViewModel(mockReporter.Object, mockWindow.Object, cacheKeep);
+
+        // Assert
+        Assert.That(viewModel.CacheKeep, Is.EqualTo(CacheKeep.Offline));
+        Assert.That(viewModel.CanResetCacheKeep, Is.True);
+    }
+
+    [Test]
+    public async Task ResetCacheKeepCommand_RestoresDefault()
+    {
+        // Arrange
+        var cacheKeep = new MemoryCacheService(CacheKeep.Always);
+        var mockReporter = new Mock<ICrashReporter>();
+        var mockWindow = new Mock<IWindowService>();
+        var viewModel = new FooterViewModel(mockReporter.Object, mockWindow.Object, cacheKeep);
+
+        // Act
+        await viewModel.ResetCacheKeepCommand.Execute();
+
+        // Assert
+        Assert.That(viewModel.CacheKeep, Is.EqualTo(CacheKeep.Offline));
+        Assert.That(viewModel.CacheKeepIndex, Is.EqualTo(1));
+        Assert.That(viewModel.CanResetCacheKeep, Is.False);
+        Assert.That(cacheKeep.CacheKeep, Is.Null);
     }
 
     [Test]


### PR DESCRIPTION
Allow configuring the default cache keep mode between
- `None`,
- `Offline` (default), or
- `Always`

For example, in `appsettings.json`:
```json
{
  "AppConfig": {
    "CacheKeep": "Always"
  }
}
```

The UI will default to:

<img width="347" height="247" alt="image" src="https://github.com/user-attachments/assets/07202ba5-0ca1-4625-8ca7-3ae7e1b035ed" />

Just like before, the user preference is persisted on changes, but now an additional subtle "reset" button appears for going back to the default:

<img width="347" height="247" alt="image" src="https://github.com/user-attachments/assets/6645b5cc-3c54-4f78-bf7e-1d9900683324" />

Close: #200 