### PR TITLE
feat: symbol demangling

### DIFF
--- a/Sentry.CrashReporter/App.xaml.cs
+++ b/Sentry.CrashReporter/App.xaml.cs
@@ -46,6 +46,7 @@ public partial class App : Application
         services.AddSingleton<IWindowService, WindowService>();
         services.AddSingleton<IClipboardService, ClipboardService>();
         services.AddSingleton<IFilePickerService, FilePickerService>();
+        services.AddSingleton<ISymbolDemangler, SymbolDemangler>();
         Ioc.Default.ConfigureServices(services.BuildServiceProvider());
         return Services;
     }

--- a/Sentry.CrashReporter/App.xaml.cs
+++ b/Sentry.CrashReporter/App.xaml.cs
@@ -46,7 +46,11 @@ public partial class App : Application
         services.AddSingleton<IWindowService, WindowService>();
         services.AddSingleton<IClipboardService, ClipboardService>();
         services.AddSingleton<IFilePickerService, FilePickerService>();
-        services.AddSingleton<ISymbolDemangler, SymbolDemangler>();
+#if __DESKTOP__
+        services.AddSingleton<ISymbolDemangler, SymbolicDemangler>();
+#else
+        services.AddSingleton<ISymbolDemangler, NullDemangler>();
+#endif
         Ioc.Default.ConfigureServices(services.BuildServiceProvider());
         return Services;
     }

--- a/Sentry.CrashReporter/Directory.Packages.props
+++ b/Sentry.CrashReporter/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="CommunityToolkit.WinUI.Converters" Version="8.2.250402" />
     <PackageVersion Include="KaitaiStruct.Runtime.CSharp" Version="0.10.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
+    <PackageVersion Include="Symbolic.NET" Version="0.1.0" />
     <PackageVersion Include="GitInfo" Version="3.6.0" />
     <PackageVersion Include="ReactiveUI.SourceGenerators" Version="2.6.30" />
     <PackageVersion Include="ReactiveUI.Uno.WinUI" Version="20.0.36" />

--- a/Sentry.CrashReporter/Sentry.CrashReporter.csproj
+++ b/Sentry.CrashReporter/Sentry.CrashReporter.csproj
@@ -120,6 +120,7 @@
         <PackageReference Include="CommunityToolkit.WinUI.Converters" />
         <PackageReference Include="KaitaiStruct.Runtime.CSharp"/>
         <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+        <PackageReference Include="Symbolic.NET" Condition="$(TargetFramework.Contains('desktop'))" />
         <PackageReference Include="ReactiveUI.SourceGenerators">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Sentry.CrashReporter/Services/SymbolDemangler.cs
+++ b/Sentry.CrashReporter/Services/SymbolDemangler.cs
@@ -5,49 +5,26 @@ public interface ISymbolDemangler
     string Demangle(string symbol);
 }
 
-public class SymbolDemangler : ISymbolDemangler
+public class NullDemangler : ISymbolDemangler
 {
-#if __DESKTOP__
-    private bool _enabled = true;
-#endif
+    public string Demangle(string symbol) => symbol;
+}
 
+#if __DESKTOP__
+public class SymbolicDemangler : ISymbolDemangler
+{
     public string Demangle(string symbol)
     {
         if (string.IsNullOrEmpty(symbol)) return symbol;
-
-#if __DESKTOP__
-        if (!_enabled) return symbol;
 
         try
         {
             return global::Sentry.Symbolic.Demangle(symbol) ?? symbol;
         }
-        catch (DllNotFoundException)
-        {
-            _enabled = false;
-            return symbol;
-        }
-        catch (EntryPointNotFoundException)
-        {
-            _enabled = false;
-            return symbol;
-        }
-        catch (BadImageFormatException)
-        {
-            _enabled = false;
-            return symbol;
-        }
-        catch (PlatformNotSupportedException)
-        {
-            _enabled = false;
-            return symbol;
-        }
         catch (Exception)
         {
             return symbol;
         }
-#else
-        return symbol;
-#endif
     }
 }
+#endif

--- a/Sentry.CrashReporter/Services/SymbolDemangler.cs
+++ b/Sentry.CrashReporter/Services/SymbolDemangler.cs
@@ -7,7 +7,7 @@ public interface ISymbolDemangler
 
 public class SymbolDemangler : ISymbolDemangler
 {
-#if DESKTOP
+#if __DESKTOP__
     private bool _enabled = true;
 #endif
 
@@ -15,7 +15,7 @@ public class SymbolDemangler : ISymbolDemangler
     {
         if (string.IsNullOrEmpty(symbol)) return symbol;
 
-#if DESKTOP
+#if __DESKTOP__
         if (!_enabled) return symbol;
 
         try

--- a/Sentry.CrashReporter/Services/SymbolDemangler.cs
+++ b/Sentry.CrashReporter/Services/SymbolDemangler.cs
@@ -42,6 +42,10 @@ public class SymbolDemangler : ISymbolDemangler
             _enabled = false;
             return symbol;
         }
+        catch (Exception)
+        {
+            return symbol;
+        }
 #else
         return symbol;
 #endif

--- a/Sentry.CrashReporter/Services/SymbolDemangler.cs
+++ b/Sentry.CrashReporter/Services/SymbolDemangler.cs
@@ -1,0 +1,49 @@
+namespace Sentry.CrashReporter.Services;
+
+public interface ISymbolDemangler
+{
+    string Demangle(string symbol);
+}
+
+public class SymbolDemangler : ISymbolDemangler
+{
+#if DESKTOP
+    private bool _enabled = true;
+#endif
+
+    public string Demangle(string symbol)
+    {
+        if (string.IsNullOrEmpty(symbol)) return symbol;
+
+#if DESKTOP
+        if (!_enabled) return symbol;
+
+        try
+        {
+            return global::Sentry.Symbolic.Demangle(symbol) ?? symbol;
+        }
+        catch (DllNotFoundException)
+        {
+            _enabled = false;
+            return symbol;
+        }
+        catch (EntryPointNotFoundException)
+        {
+            _enabled = false;
+            return symbol;
+        }
+        catch (BadImageFormatException)
+        {
+            _enabled = false;
+            return symbol;
+        }
+        catch (PlatformNotSupportedException)
+        {
+            _enabled = false;
+            return symbol;
+        }
+#else
+        return symbol;
+#endif
+    }
+}

--- a/Sentry.CrashReporter/ViewModels/StacktraceViewModel.cs
+++ b/Sentry.CrashReporter/ViewModels/StacktraceViewModel.cs
@@ -30,7 +30,7 @@ public partial class StacktraceViewModel : ReactiveObject
     {
         _symbolDemangler = symbolDemangler
             ?? TryGetSymbolDemangler()
-            ?? new SymbolDemangler();
+            ?? CreateDefaultSymbolDemangler();
 
         _threadsHelper = this.WhenAnyValue(x => x.Envelope)
             .Select(envelope =>
@@ -85,6 +85,15 @@ public partial class StacktraceViewModel : ReactiveObject
             .Select(((List<StacktraceThreadItem>? threads, int index) t) =>
                 t.threads is not null && t.index < t.threads.Count - 1);
         NextThread = ReactiveCommand.Create(() => { SelectedThreadIndex++; }, canGoNext);
+    }
+
+    private static ISymbolDemangler CreateDefaultSymbolDemangler()
+    {
+#if __DESKTOP__
+        return new SymbolicDemangler();
+#else
+        return new NullDemangler();
+#endif
     }
 
     private static ISymbolDemangler? TryGetSymbolDemangler()

--- a/Sentry.CrashReporter/ViewModels/StacktraceViewModel.cs
+++ b/Sentry.CrashReporter/ViewModels/StacktraceViewModel.cs
@@ -1,6 +1,7 @@
 using System.Reactive;
 using System.Text.Json.Nodes;
 using Sentry.CrashReporter.Extensions;
+using Sentry.CrashReporter.Services;
 
 namespace Sentry.CrashReporter.ViewModels;
 
@@ -20,12 +21,17 @@ public partial class StacktraceViewModel : ReactiveObject
     [ObservableAsProperty] private StacktraceThreadItem? _selectedThread;
     [ObservableAsProperty] private List<StacktraceFrameItem>? _frames;
     [ObservableAsProperty] private bool _hasMultipleThreads;
+    private readonly ISymbolDemangler _symbolDemangler;
 
     public ReactiveCommand<Unit, Unit> PreviousThread { get; }
     public ReactiveCommand<Unit, Unit> NextThread { get; }
 
-    public StacktraceViewModel()
+    public StacktraceViewModel(ISymbolDemangler? symbolDemangler = null)
     {
+        _symbolDemangler = symbolDemangler
+            ?? TryGetSymbolDemangler()
+            ?? new SymbolDemangler();
+
         _threadsHelper = this.WhenAnyValue(x => x.Envelope)
             .Select(envelope =>
             {
@@ -40,11 +46,11 @@ public partial class StacktraceViewModel : ReactiveObject
                             t.ThreadId == crashedThreadId,
                             t.Frames.Select(f => new StacktraceFrameItem(
                                 $"0x{f.InstructionAddr:X}",
-                                f.Symbol)).ToList()))
+                                _symbolDemangler.Demangle(f.Symbol))).ToList()))
                         .ToList();
                 }
 
-                return TryGetThreadsFromEvent(envelope);
+                return TryGetThreadsFromEvent(envelope, _symbolDemangler);
             })
             .ToProperty(this, x => x.Threads);
 
@@ -81,7 +87,21 @@ public partial class StacktraceViewModel : ReactiveObject
         NextThread = ReactiveCommand.Create(() => { SelectedThreadIndex++; }, canGoNext);
     }
 
-    private static List<StacktraceThreadItem>? TryGetThreadsFromEvent(Envelope? envelope)
+    private static ISymbolDemangler? TryGetSymbolDemangler()
+    {
+        try
+        {
+            return App.Services.GetService<ISymbolDemangler>();
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    private static List<StacktraceThreadItem>? TryGetThreadsFromEvent(
+        Envelope? envelope,
+        ISymbolDemangler symbolDemangler)
     {
         var payload = envelope?.TryGetEvent()?.TryParseAsJson();
         if (payload is null) return null;
@@ -120,7 +140,7 @@ public partial class StacktraceViewModel : ReactiveObject
                     var frames = t.TryGetProperty("stacktrace.frames");
                     if (frames is null && !exceptionFrames.TryGetValue(id, out frames) && crashed)
                         frames = unmatchedExceptionFrames;
-                    return new StacktraceThreadItem(id, name, crashed, ParseFrames(frames));
+                    return new StacktraceThreadItem(id, name, crashed, ParseFrames(frames, symbolDemangler));
                 })
                 .Where(t => t.Frames.Count > 0)
                 .ToList();
@@ -130,7 +150,7 @@ public partial class StacktraceViewModel : ReactiveObject
         // No threads interface — create entries from exceptions with stacktraces
         var result = exceptions!.OfType<JsonObject>()
             .Select(ex => new StacktraceThreadItem(
-                "", null, true, ParseFrames(ex.TryGetProperty("stacktrace.frames"))))
+                "", null, true, ParseFrames(ex.TryGetProperty("stacktrace.frames"), symbolDemangler)))
             .Where(t => t.Frames.Count > 0)
             .ToList();
         return result.Count > 0 ? result : null;
@@ -151,14 +171,14 @@ public partial class StacktraceViewModel : ReactiveObject
         _ => null
     };
 
-    private static List<StacktraceFrameItem> ParseFrames(JsonNode? framesNode)
+    private static List<StacktraceFrameItem> ParseFrames(JsonNode? framesNode, ISymbolDemangler symbolDemangler)
     {
         if (framesNode is not JsonArray frames) return [];
         return frames.OfType<JsonObject>()
             .Reverse()
             .Select(f => new StacktraceFrameItem(
                 f.TryGetString("instruction_addr") ?? "",
-                f.TryGetString("function") ?? ""))
+                symbolDemangler.Demangle(f.TryGetString("function") ?? "")))
             .ToList();
     }
 }

--- a/Sentry.CrashReporter/ViewModels/StacktraceViewModel.cs
+++ b/Sentry.CrashReporter/ViewModels/StacktraceViewModel.cs
@@ -21,16 +21,14 @@ public partial class StacktraceViewModel : ReactiveObject
     [ObservableAsProperty] private StacktraceThreadItem? _selectedThread;
     [ObservableAsProperty] private List<StacktraceFrameItem>? _frames;
     [ObservableAsProperty] private bool _hasMultipleThreads;
-    private readonly ISymbolDemangler _symbolDemangler;
+    private readonly ISymbolDemangler _demangler;
 
     public ReactiveCommand<Unit, Unit> PreviousThread { get; }
     public ReactiveCommand<Unit, Unit> NextThread { get; }
 
-    public StacktraceViewModel(ISymbolDemangler? symbolDemangler = null)
+    public StacktraceViewModel(ISymbolDemangler? demangler = null)
     {
-        _symbolDemangler = symbolDemangler
-            ?? TryGetSymbolDemangler()
-            ?? CreateDefaultSymbolDemangler();
+        _demangler = demangler ?? App.Services.GetRequiredService<ISymbolDemangler>();
 
         _threadsHelper = this.WhenAnyValue(x => x.Envelope)
             .Select(envelope =>
@@ -46,11 +44,11 @@ public partial class StacktraceViewModel : ReactiveObject
                             t.ThreadId == crashedThreadId,
                             t.Frames.Select(f => new StacktraceFrameItem(
                                 $"0x{f.InstructionAddr:X}",
-                                _symbolDemangler.Demangle(f.Symbol))).ToList()))
+                                _demangler.Demangle(f.Symbol))).ToList()))
                         .ToList();
                 }
 
-                return TryGetThreadsFromEvent(envelope, _symbolDemangler);
+                return TryGetThreadsFromEvent(envelope, _demangler);
             })
             .ToProperty(this, x => x.Threads);
 
@@ -87,30 +85,9 @@ public partial class StacktraceViewModel : ReactiveObject
         NextThread = ReactiveCommand.Create(() => { SelectedThreadIndex++; }, canGoNext);
     }
 
-    private static ISymbolDemangler CreateDefaultSymbolDemangler()
-    {
-#if __DESKTOP__
-        return new SymbolicDemangler();
-#else
-        return new NullDemangler();
-#endif
-    }
-
-    private static ISymbolDemangler? TryGetSymbolDemangler()
-    {
-        try
-        {
-            return App.Services.GetService<ISymbolDemangler>();
-        }
-        catch (InvalidOperationException)
-        {
-            return null;
-        }
-    }
-
     private static List<StacktraceThreadItem>? TryGetThreadsFromEvent(
         Envelope? envelope,
-        ISymbolDemangler symbolDemangler)
+        ISymbolDemangler demangler)
     {
         var payload = envelope?.TryGetEvent()?.TryParseAsJson();
         if (payload is null) return null;
@@ -149,7 +126,7 @@ public partial class StacktraceViewModel : ReactiveObject
                     var frames = t.TryGetProperty("stacktrace.frames");
                     if (frames is null && !exceptionFrames.TryGetValue(id, out frames) && crashed)
                         frames = unmatchedExceptionFrames;
-                    return new StacktraceThreadItem(id, name, crashed, ParseFrames(frames, symbolDemangler));
+                    return new StacktraceThreadItem(id, name, crashed, ParseFrames(frames, demangler));
                 })
                 .Where(t => t.Frames.Count > 0)
                 .ToList();
@@ -159,7 +136,7 @@ public partial class StacktraceViewModel : ReactiveObject
         // No threads interface — create entries from exceptions with stacktraces
         var result = exceptions!.OfType<JsonObject>()
             .Select(ex => new StacktraceThreadItem(
-                "", null, true, ParseFrames(ex.TryGetProperty("stacktrace.frames"), symbolDemangler)))
+                "", null, true, ParseFrames(ex.TryGetProperty("stacktrace.frames"), demangler)))
             .Where(t => t.Frames.Count > 0)
             .ToList();
         return result.Count > 0 ? result : null;
@@ -180,14 +157,14 @@ public partial class StacktraceViewModel : ReactiveObject
         _ => null
     };
 
-    private static List<StacktraceFrameItem> ParseFrames(JsonNode? framesNode, ISymbolDemangler symbolDemangler)
+    private static List<StacktraceFrameItem> ParseFrames(JsonNode? framesNode, ISymbolDemangler demangler)
     {
         if (framesNode is not JsonArray frames) return [];
         return frames.OfType<JsonObject>()
             .Reverse()
             .Select(f => new StacktraceFrameItem(
                 f.TryGetString("instruction_addr") ?? "",
-                symbolDemangler.Demangle(f.TryGetString("function") ?? "")))
+                demangler.Demangle(f.TryGetString("function") ?? "")))
             .ToList();
     }
 }

--- a/tests/Sentry.CrashReporter.RuntimeTests/RuntimeTestBase.cs
+++ b/tests/Sentry.CrashReporter.RuntimeTests/RuntimeTestBase.cs
@@ -54,6 +54,7 @@ public class RuntimeTestBase
         services.AddSingleton<ICacheService>(cacheKeep);
         services.AddSingleton(mockClipboard.Object);
         services.AddSingleton(mockFilePicker.Object);
+        services.AddSingleton<ISymbolDemangler, NullDemangler>();
         App.Services = services.BuildServiceProvider();
 
         return new MockRuntime(mockReporter, mockWindow, cacheKeep, mockClipboard, mockFilePicker);

--- a/tests/Sentry.CrashReporter.Tests/StacktraceViewModelTests.cs
+++ b/tests/Sentry.CrashReporter.Tests/StacktraceViewModelTests.cs
@@ -2,11 +2,16 @@ namespace Sentry.CrashReporter.Tests;
 
 public class StacktraceViewModelTests
 {
+    private static StacktraceViewModel CreateViewModel(Envelope? envelope = null)
+    {
+        return new StacktraceViewModel(new NullDemangler()) { Envelope = envelope };
+    }
+
     [Test]
     public void Defaults()
     {
         // Act
-        var viewModel = new StacktraceViewModel();
+        var viewModel = CreateViewModel();
 
         // Assert
         Assert.That(viewModel.Envelope, Is.Null);
@@ -24,7 +29,7 @@ public class StacktraceViewModelTests
         var envelope = await Envelope.FromFileStreamAsync(file);
 
         // Act
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
 
         // Assert
         Assert.That(viewModel.Threads, Is.Not.Null);
@@ -39,7 +44,7 @@ public class StacktraceViewModelTests
         var envelope = await Envelope.FromFileStreamAsync(file);
 
         // Act
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
 
         // Assert
         Assert.That(viewModel.Threads![0].ThreadId, Is.EqualTo("0x2CFC"));
@@ -53,7 +58,7 @@ public class StacktraceViewModelTests
         var envelope = await Envelope.FromFileStreamAsync(file);
 
         // Act
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
 
         // Assert
         Assert.That(viewModel.Threads![0].Crashed, Is.True);
@@ -68,7 +73,7 @@ public class StacktraceViewModelTests
         var envelope = await Envelope.FromFileStreamAsync(file);
 
         // Act
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
 
         // Assert
         Assert.That(viewModel.SelectedThreadIndex, Is.EqualTo(0));
@@ -84,7 +89,7 @@ public class StacktraceViewModelTests
         var envelope = await Envelope.FromFileStreamAsync(file);
 
         // Act
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
 
         // Assert
         Assert.That(viewModel.Frames, Is.Not.Null);
@@ -117,7 +122,7 @@ public class StacktraceViewModelTests
         // Arrange
         await using var file = File.OpenRead("data/crashpad.envelope");
         var envelope = await Envelope.FromFileStreamAsync(file);
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
 
         // Act
         viewModel.NextThread.Execute().Subscribe();
@@ -134,7 +139,7 @@ public class StacktraceViewModelTests
         // Arrange
         await using var file = File.OpenRead("data/crashpad.envelope");
         var envelope = await Envelope.FromFileStreamAsync(file);
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
         viewModel.SelectedThreadIndex = 2;
 
         // Act
@@ -150,7 +155,7 @@ public class StacktraceViewModelTests
         // Arrange
         await using var file = File.OpenRead("data/crashpad.envelope");
         var envelope = await Envelope.FromFileStreamAsync(file);
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
 
         // Act
         viewModel.SelectedThreadIndex = viewModel.Threads!.Count - 1;
@@ -167,7 +172,7 @@ public class StacktraceViewModelTests
         // Arrange
         await using var file = File.OpenRead("data/crashpad.envelope");
         var envelope = await Envelope.FromFileStreamAsync(file);
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
 
         // Assert
         bool canExecute = false;
@@ -182,7 +187,7 @@ public class StacktraceViewModelTests
         // Arrange
         await using var file = File.OpenRead("data/crashpad.envelope");
         var envelope = await Envelope.FromFileStreamAsync(file);
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
 
         // Act
         viewModel.SelectedThreadIndex = 1;
@@ -200,7 +205,7 @@ public class StacktraceViewModelTests
         var envelope = await Envelope.FromFileStreamAsync(file);
 
         // Act
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
 
         // Assert
         Assert.That(viewModel.Threads, Is.Null);
@@ -216,7 +221,7 @@ public class StacktraceViewModelTests
         var envelope = await Envelope.FromFileStreamAsync(file);
 
         // Act
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
 
         // Assert
         Assert.That(viewModel.Threads, Has.Count.EqualTo(3));
@@ -230,7 +235,7 @@ public class StacktraceViewModelTests
         var envelope = await Envelope.FromFileStreamAsync(file);
 
         // Act
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
 
         // Assert — crashed thread gets frames from exception via thread_id
         Assert.That(viewModel.Threads![0].ThreadId, Is.EqualTo("1000"));
@@ -249,7 +254,7 @@ public class StacktraceViewModelTests
         var envelope = await Envelope.FromFileStreamAsync(file);
 
         // Act
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
 
         // Assert
         Assert.That(viewModel.Threads![1].ThreadId, Is.EqualTo("1001"));
@@ -283,7 +288,7 @@ public class StacktraceViewModelTests
         ]);
 
         // Act
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
 
         // Assert
         Assert.That(viewModel.Threads, Has.Count.EqualTo(1));
@@ -339,7 +344,7 @@ public class StacktraceViewModelTests
         var envelope = await Envelope.FromFileStreamAsync(file);
 
         // Act
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
 
         // Assert
         Assert.That(viewModel.Threads, Has.Count.EqualTo(15));
@@ -357,7 +362,7 @@ public class StacktraceViewModelTests
         var envelope = await Envelope.FromFileStreamAsync(file);
 
         // Act
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
 
         // Assert — named threads
         Assert.That(viewModel.Threads![0].Name, Is.EqualTo("main"));
@@ -401,7 +406,7 @@ public class StacktraceViewModelTests
         ]);
 
         // Act
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
 
         // Assert — only the crashed thread (with exception frames) is returned
         Assert.That(viewModel.Threads, Has.Count.EqualTo(1));
@@ -426,7 +431,7 @@ public class StacktraceViewModelTests
         ]);
 
         // Act
-        var viewModel = new StacktraceViewModel { Envelope = envelope };
+        var viewModel = CreateViewModel(envelope);
 
         // Assert
         Assert.That(viewModel.Threads, Is.Null);

--- a/tests/Sentry.CrashReporter.Tests/StacktraceViewModelTests.cs
+++ b/tests/Sentry.CrashReporter.Tests/StacktraceViewModelTests.cs
@@ -94,6 +94,24 @@ public class StacktraceViewModelTests
     }
 
     [Test]
+    public async Task Init_WithStacktrace_DemanglesSymbols()
+    {
+        // Arrange
+        await using var file = File.OpenRead("data/crashpad.envelope");
+        var envelope = await Envelope.FromFileStreamAsync(file);
+        var demangler = new Mock<ISymbolDemangler>();
+        demangler.Setup(x => x.Demangle(It.IsAny<string>()))
+            .Returns<string>(symbol => symbol);
+        demangler.Setup(x => x.Demangle("memset")).Returns("demangled memset");
+
+        // Act
+        var viewModel = new StacktraceViewModel(demangler.Object) { Envelope = envelope };
+
+        // Assert
+        Assert.That(viewModel.Frames![0].Symbol, Is.EqualTo("demangled memset"));
+    }
+
+    [Test]
     public async Task NextThread_AdvancesIndex()
     {
         // Arrange
@@ -272,6 +290,45 @@ public class StacktraceViewModelTests
         Assert.That(viewModel.Threads![0].Crashed, Is.True);
         Assert.That(viewModel.Threads[0].Frames, Has.Count.EqualTo(1));
         Assert.That(viewModel.Threads[0].Frames[0].Symbol, Is.EqualTo("segfault"));
+    }
+
+    [Test]
+    public void Init_EventStacktrace_DemanglesSymbols()
+    {
+        // Arrange
+        var envelope = new Envelope(new JsonObject(), [
+            new EnvelopeItem(new JsonObject { ["type"] = "event" },
+                Encoding.UTF8.GetBytes(new JsonObject
+                {
+                    ["exception"] = new JsonObject
+                    {
+                        ["values"] = new JsonArray(
+                            new JsonObject
+                            {
+                                ["type"] = "SIGSEGV",
+                                ["stacktrace"] = new JsonObject
+                                {
+                                    ["frames"] = new JsonArray(
+                                        new JsonObject
+                                        {
+                                            ["instruction_addr"] = "0x1234",
+                                            ["function"] = "_ZN3foo3barEv"
+                                        })
+                                }
+                            })
+                    }
+                }.ToJsonString()))
+        ]);
+        var demangler = new Mock<ISymbolDemangler>();
+        demangler.Setup(x => x.Demangle(It.IsAny<string>()))
+            .Returns<string>(symbol => symbol);
+        demangler.Setup(x => x.Demangle("_ZN3foo3barEv")).Returns("foo::bar()");
+
+        // Act
+        var viewModel = new StacktraceViewModel(demangler.Object) { Envelope = envelope };
+
+        // Assert
+        Assert.That(viewModel.Threads![0].Frames[0].Symbol, Is.EqualTo("foo::bar()"));
     }
 
     [Test]


### PR DESCRIPTION
Adds symbol demangling via [Symbolic.NET](https://www.nuget.org/packages/Symbolic.NET), which provides lightweight .NET bindings for Sentry’s [symbolic](https://github.com/getsentry/symbolic). This makes mangled C++ symbols readable in the crash reporter UI.

- Demangles minidump and event JSON stacktrace symbols before display.
- Preserves the original symbol when demangling is unavailable or not applicable.

| Before | After |
|---|---|
| <img width="1900" height="1374" alt="Screenshot From 2026-05-25 15-29-08" src="https://github.com/user-attachments/assets/cd3e00f8-2e41-4e57-b05e-dd552a11a2be" /> | <img width="1900" height="1374" alt="Screenshot From 2026-05-25 15-31-14" src="https://github.com/user-attachments/assets/8005a8ce-3bf8-44dd-8f2a-b9638154dd2d" /> |

See also:
- https://github.com/getsentry/sentry-native/pull/1747