### PR TITLE
chore: add Makefile helpers for convenience

### DIFF
--- a/.github/scripts/run-ui-tests.ps1
+++ b/.github/scripts/run-ui-tests.ps1
@@ -1,5 +1,6 @@
 param(
-    [switch] $Clean
+    [switch] $Clean,
+    [string] $Configuration = "Release"
 )
 
 Set-StrictMode -Version latest
@@ -8,7 +9,9 @@ $ErrorActionPreference = 'Stop'
 $env:UNO_UITEST_PLATFORM = "Browser"
 $env:UNO_UITEST_TARGETURI = "http://localhost:5000"
 $env:UNO_UITEST_CHROME_CONTAINER_MODE = $true
-$env:UNO_UITEST_DRIVER_PATH = $env:CHROMEWEBDRIVER
+if ([string]::IsNullOrWhiteSpace($env:UNO_UITEST_DRIVER_PATH)) {
+    $env:UNO_UITEST_DRIVER_PATH = $env:CHROMEWEBDRIVER
+}
 
 function Stop-UiTestProcesses {
     param(
@@ -18,7 +21,7 @@ function Stop-UiTestProcesses {
     if ($null -ne $Server) {
         try {
             if (!$Server.HasExited) {
-                Stop-Process -Id $Server.Id -Force -ErrorAction SilentlyContinue
+                $Server.Kill($true)
                 $Server.WaitForExit(5000) | Out-Null
             }
         }
@@ -38,10 +41,10 @@ if ($Clean) {
 }
 
 $server = $null
-$server = Start-Process -FilePath dotnet -ArgumentList "run --no-build -c Release -f net10.0-browserwasm --project Sentry.CrashReporter/Sentry.CrashReporter.csproj --launch-profile ""Sentry.CrashReporter (WebAssembly)""" -PassThru
+$server = Start-Process -FilePath dotnet -ArgumentList "run --no-build -c $Configuration -f net10.0-browserwasm --project Sentry.CrashReporter/Sentry.CrashReporter.csproj --launch-profile ""Sentry.CrashReporter (WebAssembly)""" -PassThru
 try
 {
-    dotnet test --no-build -c Release -f net10.0 -l GitHubActions -l trx tests/Sentry.CrashReporter.UITests/Sentry.CrashReporter.UITests.csproj
+    dotnet test --no-build -c $Configuration -f net10.0 -l GitHubActions -l trx tests/Sentry.CrashReporter.UITests/Sentry.CrashReporter.UITests.csproj
 }
 finally
 {

--- a/.github/scripts/run-ui-tests.ps1
+++ b/.github/scripts/run-ui-tests.ps1
@@ -23,6 +23,7 @@ function Stop-UiTestProcesses {
             if (!$Server.HasExited) {
                 $Server.Kill($true)
                 $Server.WaitForExit(5000) | Out-Null
+                Start-Sleep -Seconds 1
             }
         }
         catch {

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,73 @@
+.DEFAULT_GOAL := help
+
+DOTNET ?= dotnet
+
+PROJECT := Sentry.CrashReporter/Sentry.CrashReporter.csproj
+SOLUTION := Sentry.CrashReporter.sln
+UNIT_TEST_PROJECT := tests/Sentry.CrashReporter.Tests/Sentry.CrashReporter.Tests.csproj
+UI_TEST_PROJECT := tests/Sentry.CrashReporter.UITests/Sentry.CrashReporter.UITests.csproj
+RUNTIME_TEST_HOST_PROJECT := tests/Sentry.CrashReporter.RuntimeTests.Host/Sentry.CrashReporter.RuntimeTests.Host.csproj
+
+CONFIG ?=
+FRAMEWORK ?= net10.0-desktop
+RID ?= $(shell $(DOTNET) --info | awk '$$1 == "RID:" { print $$2; exit }')
+OUTPUT ?=
+
+RUNTIME_TEST_OUTPUT := tests/Sentry.CrashReporter.RuntimeTests/TestResults
+RUNTIME_TEST_HOST_DLL = tests/Sentry.CrashReporter.RuntimeTests.Host/bin/$(or $(CONFIG),Debug)/net10.0-desktop/Sentry.CrashReporter.RuntimeTests.Host.dll
+
+ifneq ($(filter run test,$(firstword $(MAKECMDGOALS))),)
+ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+.PHONY: $(ARGS)
+$(ARGS):
+	@:
+endif
+
+.PHONY: help restore build run publish test test-runtime test-ui
+
+help:
+	@printf "Targets:\n"
+	@printf "  make build          Build the desktop app ($(or $(CONFIG),Debug), $(FRAMEWORK))\n"
+	@printf "  make run            Run the desktop app ($(or $(CONFIG),Debug), $(FRAMEWORK))\n"
+	@printf "  make publish        Publish the desktop app ($(or $(CONFIG),Release), $(FRAMEWORK), $(RID))\n"
+	@printf "  make test           Run unit tests ($(or $(CONFIG),Debug))\n"
+	@printf "  make test-runtime   Build and run Uno runtime tests under xvfb ($(or $(CONFIG),Debug))\n"
+	@printf "  make test-ui        Build and run WebAssembly UI tests ($(or $(CONFIG),Debug))\n"
+	@printf "\n"
+	@printf "Variables:\n"
+	@printf "  CONFIG              Debug/Release\n"
+	@printf "  RID                 win-x64/osx-arm64/linux-x64/...\n"
+	@printf "  OUTPUT              publish output path\n"
+	@printf "\n"
+	@printf "Common overrides:\n"
+	@printf "  make run -- path/to/file.envelope\n"
+	@printf "  make test -- --filter FullyQualifiedName~Submit\n"
+	@printf "  make publish RID=osx-arm64\n"
+	@printf "  make publish RID=win-x64 OUTPUT=build\n"
+	@printf "  make build CONFIG=Release\n"
+
+restore:
+	$(DOTNET) restore $(SOLUTION)
+
+build:
+	$(DOTNET) build -c $(or $(CONFIG),Debug) -f $(FRAMEWORK) $(PROJECT)
+
+run:
+	$(DOTNET) run --project $(PROJECT) -c $(or $(CONFIG),Debug) -f $(FRAMEWORK) -- $(or $(ARGS),tests/data/inproc.envelope)
+
+publish:
+	$(DOTNET) publish -c $(or $(CONFIG),Release) -f $(FRAMEWORK) -r $(RID) $(PROJECT) $(if $(OUTPUT),-o $(OUTPUT))
+
+
+test:
+	$(DOTNET) build $(UNIT_TEST_PROJECT) /p:Configuration=$(or $(CONFIG),Debug) /p:OverrideTargetFramework=net10.0
+	$(DOTNET) test $(UNIT_TEST_PROJECT) --no-build -c $(or $(CONFIG),Debug) --blame-crash $(ARGS)
+
+test-runtime:
+	$(DOTNET) build -c $(or $(CONFIG),Debug) -f net10.0-desktop $(RUNTIME_TEST_HOST_PROJECT)
+	UNO_RUNTIME_TESTS_RUN_TESTS='{}' UNO_RUNTIME_TESTS_OUTPUT_PATH=$(RUNTIME_TEST_OUTPUT)/RuntimeTests.xml xvfb-run -a $(DOTNET) $(RUNTIME_TEST_HOST_DLL)
+
+test-ui:
+	$(DOTNET) build -c $(or $(CONFIG),Debug) -f net10.0-browserwasm -p:IsUiAutomationMappingEnabled=True $(PROJECT)
+	$(DOTNET) build -c $(or $(CONFIG),Debug) -f net10.0 $(UI_TEST_PROJECT)
+	pwsh .github/scripts/run-ui-tests.ps1 -Configuration $(or $(CONFIG),Debug)

--- a/Sentry.CrashReporter/Sentry.CrashReporter.csproj
+++ b/Sentry.CrashReporter/Sentry.CrashReporter.csproj
@@ -5,6 +5,7 @@
         <OutputType>Exe</OutputType>
         <!--PublishAot>true</PublishAot-->
         <UnoSingleProject>true</UnoSingleProject>
+        <UseSystemResourceKeys>false</UseSystemResourceKeys>
 
         <!-- Display name -->
         <ApplicationTitle>Sentry Crash Reporter</ApplicationTitle>
@@ -70,7 +71,6 @@
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
         <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
-        <UseSystemResourceKeys>false</UseSystemResourceKeys>
 
         <UnoXamlResourcesTrimming>false</UnoXamlResourcesTrimming>
         <PublishTrimmed>true</PublishTrimmed>


### PR DESCRIPTION
Add Makefile targets for restoring, building, running, publishing, and testing the crash reporter. Default publish to the host `RID` while keeping `CONFIG`, `RID`, `FRAMEWORK`, and `OUTPUT` overrideable.

Support passing run and unit-test arguments after `--`, while keeping the default envelope and blame-crash behavior.

Make UI test runs configurable, preserve an existing ChromeDriver path, and terminate the launched WebAssembly process tree after tests exit.

Disable system resource keys for all app builds so UI-visible exception messages remain stable in `Debug` and `Release`.

```sh
$ make help
Targets:
  make build          Build the desktop app (Debug, net10.0-desktop)
  make run            Run the desktop app (Debug, net10.0-desktop)
  make publish        Publish the desktop app (Release, net10.0-desktop, linux-x64)
  make test           Run unit tests (Debug)
  make test-runtime   Build and run Uno runtime tests under xvfb (Debug)
  make test-ui        Build and run WebAssembly UI tests (Debug)

Variables:
  CONFIG              Debug/Release
  RID                 win-x64/osx-arm64/linux-x64/...
  OUTPUT              publish output path

Common overrides:
  make run -- path/to/file.envelope
  make test -- --filter FullyQualifiedName~Submit
  make publish RID=osx-arm64
  make publish RID=win-x64 OUTPUT=build
  make build CONFIG=Release
```