### PR TITLE
feat: configurable HTTP timeout & retry

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -117,6 +117,8 @@ settings into the sentry-native database directory.
     "WindowClosable": false,
     "HeaderText": "Something Went Wrong",
     "CacheKeep": "Always",
+    "HttpRetry": 5,
+    "HttpTimeout": 90,
     "LogoLight": "branding/logo-light.png",
     "LogoDark": "branding/logo-dark.png",
     "SystemAccentColor": "#4CAF50"
@@ -135,6 +137,8 @@ settings into the sentry-native database directory.
 | `CancelButton` | Cancel button label. Set to empty string to hide the button. |
 | `SubmitButton` | Submit button label. |
 | `CacheKeep` | Initial cache mode when the user has not selected one. Supported values: `None`, `Offline`, `Always`. Defaults to `Offline`. |
+| `HttpRetry` | Number of retries for failed envelope submission attempts. Defaults to `3`. |
+| `HttpTimeout` | Per-attempt timeout in seconds for envelope submission. Defaults to `60`. |
 | `LogoLight` | Path to a custom logo image for light theme (relative to the binary or absolute). |
 | `LogoDark` | Path to a custom logo image for dark theme (relative to the binary or absolute). |
 | `SystemAccentColor` | Primary brand color (`#RRGGBB` or `#AARRGGBB`). |

--- a/Sentry.CrashReporter/App.xaml.cs
+++ b/Sentry.CrashReporter/App.xaml.cs
@@ -23,8 +23,12 @@ public partial class App : Application
     public static IServiceProvider ConfigureServices(StorageFile? file, ICacheService? cache = null)
     {
         var services = new ServiceCollection();
+        var envelopeDir = Path.GetDirectoryName(file?.Path);
+        var databaseDir = Path.GetDirectoryName(envelopeDir);
+        var config = AppConfig.Load(envelopeDir, databaseDir, AppContext.BaseDirectory) ?? new AppConfig();
+
         services.AddHttpClient()
-            .ConfigureHttpClientDefaults(b => b.AddStandardResilienceHandler(ConfigureResilience));
+            .ConfigureHttpClientDefaults(b => b.AddStandardResilienceHandler(options => ConfigureResilience(options, config)));
         if (file is not null)
         {
             services.AddSingleton<IStorageFile>(file);
@@ -39,10 +43,7 @@ public partial class App : Application
         {
             services.AddSingleton<ICacheService, CacheService>();
         }
-        var envelopeDir = Path.GetDirectoryName(file?.Path);
-        var databaseDir = Path.GetDirectoryName(envelopeDir);
-        var config = AppConfig.Load(envelopeDir, databaseDir, AppContext.BaseDirectory);
-        services.AddSingleton<AppConfig>(config ?? new AppConfig());
+        services.AddSingleton<AppConfig>(config);
         services.AddSingleton<IWindowService, WindowService>();
         services.AddSingleton<IClipboardService, ClipboardService>();
         services.AddSingleton<IFilePickerService, FilePickerService>();
@@ -55,10 +56,17 @@ public partial class App : Application
         return Services;
     }
 
-    public static void ConfigureResilience(HttpStandardResilienceOptions options)
+    public static void ConfigureResilience(HttpStandardResilienceOptions options, AppConfig config)
     {
-        options.Retry.MaxRetryAttempts = 3; // default
-        options.Retry.Delay = TimeSpan.FromSeconds(2); // default
+        var maxRetryAttempts = Math.Max(config.HttpRetry ?? 3, 0);
+        var retryDelay = TimeSpan.FromSeconds(2);
+        var attemptTimeout = TimeSpan.FromSeconds(Math.Max(config.HttpTimeout ?? 60, 1));
+
+        options.AttemptTimeout.Timeout = attemptTimeout;
+        options.TotalRequestTimeout.Timeout = (attemptTimeout + retryDelay) * (maxRetryAttempts + 1);
+        options.CircuitBreaker.SamplingDuration = attemptTimeout * 2;
+        options.Retry.MaxRetryAttempts = maxRetryAttempts;
+        options.Retry.Delay = retryDelay;
         options.Retry.ShouldHandle = args => ValueTask.FromResult(
             args.Outcome.Exception is HttpRequestException ||
             (args.Outcome.Result?.StatusCode >= HttpStatusCode.InternalServerError) ||

--- a/Sentry.CrashReporter/Models/AppConfig.cs
+++ b/Sentry.CrashReporter/Models/AppConfig.cs
@@ -32,6 +32,8 @@ public record AppConfig
     public string? LogoDark { get; init; }
     [JsonConverter(typeof(JsonStringEnumConverter<CacheKeep>))]
     public CacheKeep? CacheKeep { get; init; }
+    public int? HttpRetry { get; init; }
+    public int? HttpTimeout { get; init; }
 
     private const string FileName = "appsettings.json";
 

--- a/tests/Sentry.CrashReporter.Tests/AppConfigTests.cs
+++ b/tests/Sentry.CrashReporter.Tests/AppConfigTests.cs
@@ -176,6 +176,25 @@ public class AppConfigTests
     }
 
     [Test]
+    public void Load_HttpResilienceSettings_ReturnValues()
+    {
+        var dir = WriteConfig("""
+        {
+          "AppConfig": {
+            "HttpRetry": 5,
+            "HttpTimeout": 90
+          }
+        }
+        """);
+
+        var result = AppConfig.Load(dir);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.HttpRetry, Is.EqualTo(5));
+        Assert.That(result.HttpTimeout, Is.EqualTo(90));
+    }
+
+    [Test]
     public void Load_EmptyCancelButtonText_ReturnsEmptyString()
     {
         var dir = WriteConfig("""

--- a/tests/Sentry.CrashReporter.Tests/SentryClientTests.cs
+++ b/tests/Sentry.CrashReporter.Tests/SentryClientTests.cs
@@ -17,7 +17,7 @@ public class SentryClientTests
             .ConfigurePrimaryHttpMessageHandler(() => _messageHandler.Object)
             .AddStandardResilienceHandler(options =>
             {
-                App.ConfigureResilience(options);
+                App.ConfigureResilience(options, new AppConfig());
                 options.Retry.Delay = TimeSpan.FromMilliseconds(1);
             });
         var serviceProvider = services.BuildServiceProvider();


### PR DESCRIPTION
Add app-level HTTP resilience settings for envelope submission and bump up the default 10s timeout.

Read `HttpRetry` and `HttpTimeout` from `AppConfig` and apply them to standard resilience retry and attempt timeout configuration. Keep total request timeout and circuit breaker sampling derived from those values to pass HTTP resilience options validation.

Close: #220 