### PR TITLE
fix: window close / process exit in release mode

### DIFF
--- a/Sentry.CrashReporter/Services/WindowService.cs
+++ b/Sentry.CrashReporter/Services/WindowService.cs
@@ -24,6 +24,7 @@ public class WindowService : IWindowService
     {
         _window = window;
         window.AppWindow.Closing += OnClosing;
+        window.Closed += (_, _) => Application.Current?.Exit();
     }
 
     public void SetClosable(bool closable)

--- a/Sentry.CrashReporter/ViewModels/FooterViewModel.cs
+++ b/Sentry.CrashReporter/ViewModels/FooterViewModel.cs
@@ -201,6 +201,7 @@ public partial class FooterViewModel : ReactiveObject
         try
         {
             await _reporter.SubmitAsync(_envelope!);
+            await Task.Yield();
             _window.Close();
         }
         catch (Exception e)

--- a/tests/Sentry.CrashReporter.RuntimeTests/FooterViewTests.cs
+++ b/tests/Sentry.CrashReporter.RuntimeTests/FooterViewTests.cs
@@ -174,6 +174,7 @@ public class FooterViewTests : RuntimeTestBase
 
         var submitButton = view.FindFirstDescendant<Button>("submitButton");
         submitButton?.Command.Execute(null);
+        await UnitTestsUIContentHelper.WaitForIdle();
 
         // Assert
         mockRuntime.Reporter.Verify(x => x.SubmitAsync(envelope, It.IsAny<CancellationToken>()), Times.Once);


### PR DESCRIPTION
Fixes an obscure Release-mode-only window close / process exit regression accidentally found while testing timeout exceptions (#220). According to git bisect, it was already caused by caching on close (#170), but it's not 100% clear why only Release mode is affected - most likely because Uno's Studio Mode changes timings in Debug mode.

### Before
https://github.com/user-attachments/assets/34329e59-263f-4d95-85a9-1742d46b7a55

### After
https://github.com/user-attachments/assets/73e0eae2-80f6-4d96-bf03-211a79069b4e

