### PR TITLE
feat: display frame image names in the stacktrace view

### DIFF
--- a/Sentry.CrashReporter/Models/Envelope.cs
+++ b/Sentry.CrashReporter/Models/Envelope.cs
@@ -227,6 +227,11 @@ public sealed class Envelope
         return TryGetStream<Minidump.StacktraceStream>(Minidump.StreamTypes.SentryStacktrace);
     }
 
+    public Minidump.ModuleList? TryGetModuleList()
+    {
+        return TryGetStream<Minidump.ModuleList>(Minidump.StreamTypes.ModuleList);
+    }
+
     private T? TryGetStream<T>(Minidump.StreamTypes type) where T : class
     {
         try

--- a/Sentry.CrashReporter/Models/Minidump.cs
+++ b/Sentry.CrashReporter/Models/Minidump.cs
@@ -721,14 +721,27 @@ public class Minidump : KaitaiStruct
                     return _name;
                 }
 
+                if (OfsModuleName == 0)
+                {
+                    _name = "";
+                    f_name = true;
+                    return _name;
+                }
+
                 var io = M_Root.M_Io;
                 var _pos = io.Pos;
-                io.Seek(OfsModuleName);
-                var len = io.ReadU4le();
-                _name = Encoding.GetEncoding("UTF-16LE").GetString(io.ReadBytes(len));
-                io.Seek(_pos);
-                f_name = true;
-                return _name;
+                try
+                {
+                    io.Seek(OfsModuleName);
+                    var len = io.ReadU4le();
+                    _name = Encoding.GetEncoding("UTF-16LE").GetString(io.ReadBytes(len));
+                    f_name = true;
+                    return _name;
+                }
+                finally
+                {
+                    io.Seek(_pos);
+                }
             }
         }
 

--- a/Sentry.CrashReporter/Models/Minidump.cs
+++ b/Sentry.CrashReporter/Models/Minidump.cs
@@ -545,6 +545,13 @@ public class Minidump : KaitaiStruct
                         _data = new ThreadList(io___raw_data, this, M_Root);
                         break;
                     }
+                    case StreamTypes.ModuleList:
+                    {
+                        M_RawData = m_io.ReadBytes(LenData);
+                        var io___raw_data = new KaitaiStream(M_RawData);
+                        _data = new ModuleList(io___raw_data, this, M_Root);
+                        break;
+                    }
                     case StreamTypes.Exception:
                     {
                         M_RawData = m_io.ReadBytes(LenData);
@@ -648,6 +655,106 @@ public class Minidump : KaitaiStruct
         public Minidump M_Root { get; }
 
         public ThreadList M_Parent { get; }
+    }
+
+    public class ModuleList : KaitaiStruct
+    {
+        public ModuleList(KaitaiStream p__io, Dir p__parent = null, Minidump p__root = null) : base(p__io)
+        {
+            M_Parent = p__parent;
+            M_Root = p__root;
+            _read();
+        }
+
+        private void _read()
+        {
+            NumModules = m_io.ReadU4le();
+            Modules = new List<Module>();
+            for (var i = 0; i < NumModules; i++)
+            {
+                Modules.Add(new Module(m_io, this, M_Root));
+            }
+        }
+
+        public uint NumModules { get; private set; }
+
+        public List<Module> Modules { get; private set; }
+
+        public Minidump M_Root { get; }
+
+        public Dir M_Parent { get; }
+    }
+
+    public class Module : KaitaiStruct
+    {
+        public Module(KaitaiStream p__io, ModuleList p__parent = null, Minidump p__root = null) : base(p__io)
+        {
+            M_Parent = p__parent;
+            M_Root = p__root;
+            f_name = false;
+            _read();
+        }
+
+        private void _read()
+        {
+            BaseOfImage = m_io.ReadU8le();
+            SizeOfImage = m_io.ReadU4le();
+            CheckSum = m_io.ReadU4le();
+            TimeDateStamp = m_io.ReadU4le();
+            OfsModuleName = m_io.ReadU4le();
+            VersionInfo = m_io.ReadBytes(52);
+            CvRecord = new LocationDescriptor(m_io, this, M_Root);
+            MiscRecord = new LocationDescriptor(m_io, this, M_Root);
+            Reserved0 = m_io.ReadU8le();
+            Reserved1 = m_io.ReadU8le();
+        }
+
+        private bool f_name;
+        private string _name;
+
+        public string Name
+        {
+            get
+            {
+                if (f_name)
+                {
+                    return _name;
+                }
+
+                var io = M_Root.M_Io;
+                var _pos = io.Pos;
+                io.Seek(OfsModuleName);
+                var len = io.ReadU4le();
+                _name = Encoding.GetEncoding("UTF-16LE").GetString(io.ReadBytes(len));
+                io.Seek(_pos);
+                f_name = true;
+                return _name;
+            }
+        }
+
+        public ulong BaseOfImage { get; private set; }
+
+        public uint SizeOfImage { get; private set; }
+
+        public uint CheckSum { get; private set; }
+
+        public uint TimeDateStamp { get; private set; }
+
+        public uint OfsModuleName { get; private set; }
+
+        public byte[] VersionInfo { get; private set; }
+
+        public LocationDescriptor CvRecord { get; private set; }
+
+        public LocationDescriptor MiscRecord { get; private set; }
+
+        public ulong Reserved0 { get; private set; }
+
+        public ulong Reserved1 { get; private set; }
+
+        public Minidump M_Root { get; }
+
+        public ModuleList M_Parent { get; }
     }
 
     /// <remarks>

--- a/Sentry.CrashReporter/ViewModels/StacktraceViewModel.cs
+++ b/Sentry.CrashReporter/ViewModels/StacktraceViewModel.cs
@@ -38,8 +38,7 @@ public partial class StacktraceViewModel : ReactiveObject
                 var stacktrace = envelope?.TryGetStacktrace();
                 if (stacktrace is not null)
                 {
-                    var images = ParseImages(envelope?.TryGetEvent()?.TryParseAsJson());
-                    images.AddRange(ParseImages(envelope?.TryGetModuleList()));
+                    var images = ParseImages(envelope);
                     var crashedThreadId = envelope?.TryGetCrashedThreadId();
                     return stacktrace.Threads
                         .Select(t => new StacktraceThreadItem(
@@ -99,8 +98,7 @@ public partial class StacktraceViewModel : ReactiveObject
 
         var exceptions = payload.TryGetProperty("exception.values") as JsonArray;
         var threads = payload.TryGetProperty("threads.values") as JsonArray;
-        var images = ParseImages(payload);
-        images.AddRange(ParseImages(envelope?.TryGetModuleList()));
+        var images = ParseImages(envelope);
 
         if (threads is not { Count: > 0 } && exceptions is null) return null;
 
@@ -220,6 +218,14 @@ public partial class StacktraceViewModel : ReactiveObject
                 return new StacktraceImageItem(address, size, GetFileName(file));
             })
             .OfType<StacktraceImageItem>()
+            .OrderBy(image => image.Address)
+            .ToList();
+    }
+
+    private static List<StacktraceImageItem> ParseImages(Envelope? envelope)
+    {
+        return ParseImages(envelope?.TryGetEvent()?.TryParseAsJson())
+            .Concat(ParseImages(envelope?.TryGetModuleList()))
             .OrderBy(image => image.Address)
             .ToList();
     }

--- a/Sentry.CrashReporter/ViewModels/StacktraceViewModel.cs
+++ b/Sentry.CrashReporter/ViewModels/StacktraceViewModel.cs
@@ -1,15 +1,17 @@
 using System.Reactive;
+using System.Globalization;
 using System.Text.Json.Nodes;
 using Sentry.CrashReporter.Extensions;
 using Sentry.CrashReporter.Services;
 
 namespace Sentry.CrashReporter.ViewModels;
 
-public class StacktraceFrameItem(string Address, string Symbol)
+public class StacktraceFrameItem(string Image, string Address, string Symbol)
 {
+    public string Image { get; } = Image;
     public string Address { get; } = Address;
     public string Symbol { get; } = Symbol;
-    public override string ToString() => $"{Address}  {Symbol}";
+    public override string ToString() => $"{Image}  {Address}  {Symbol}";
 }
 public record StacktraceThreadItem(string ThreadId, string? Name, bool Crashed, List<StacktraceFrameItem> Frames);
 
@@ -36,6 +38,8 @@ public partial class StacktraceViewModel : ReactiveObject
                 var stacktrace = envelope?.TryGetStacktrace();
                 if (stacktrace is not null)
                 {
+                    var images = ParseImages(envelope?.TryGetEvent()?.TryParseAsJson());
+                    images.AddRange(ParseImages(envelope?.TryGetModuleList()));
                     var crashedThreadId = envelope?.TryGetCrashedThreadId();
                     return stacktrace.Threads
                         .Select(t => new StacktraceThreadItem(
@@ -43,6 +47,7 @@ public partial class StacktraceViewModel : ReactiveObject
                             null,
                             t.ThreadId == crashedThreadId,
                             t.Frames.Select(f => new StacktraceFrameItem(
+                                FindImageName(images, f.InstructionAddr),
                                 $"0x{f.InstructionAddr:X}",
                                 _demangler.Demangle(f.Symbol))).ToList()))
                         .ToList();
@@ -94,6 +99,8 @@ public partial class StacktraceViewModel : ReactiveObject
 
         var exceptions = payload.TryGetProperty("exception.values") as JsonArray;
         var threads = payload.TryGetProperty("threads.values") as JsonArray;
+        var images = ParseImages(payload);
+        images.AddRange(ParseImages(envelope?.TryGetModuleList()));
 
         if (threads is not { Count: > 0 } && exceptions is null) return null;
 
@@ -126,7 +133,7 @@ public partial class StacktraceViewModel : ReactiveObject
                     var frames = t.TryGetProperty("stacktrace.frames");
                     if (frames is null && !exceptionFrames.TryGetValue(id, out frames) && crashed)
                         frames = unmatchedExceptionFrames;
-                    return new StacktraceThreadItem(id, name, crashed, ParseFrames(frames, demangler));
+                    return new StacktraceThreadItem(id, name, crashed, ParseFrames(frames, demangler, images));
                 })
                 .Where(t => t.Frames.Count > 0)
                 .ToList();
@@ -136,7 +143,7 @@ public partial class StacktraceViewModel : ReactiveObject
         // No threads interface — create entries from exceptions with stacktraces
         var result = exceptions!.OfType<JsonObject>()
             .Select(ex => new StacktraceThreadItem(
-                "", null, true, ParseFrames(ex.TryGetProperty("stacktrace.frames"), demangler)))
+                "", null, true, ParseFrames(ex.TryGetProperty("stacktrace.frames"), demangler, images)))
             .Where(t => t.Frames.Count > 0)
             .ToList();
         return result.Count > 0 ? result : null;
@@ -157,14 +164,145 @@ public partial class StacktraceViewModel : ReactiveObject
         _ => null
     };
 
-    private static List<StacktraceFrameItem> ParseFrames(JsonNode? framesNode, ISymbolDemangler demangler)
+    private static List<StacktraceFrameItem> ParseFrames(
+        JsonNode? framesNode,
+        ISymbolDemangler demangler,
+        List<StacktraceImageItem> images)
     {
         if (framesNode is not JsonArray frames) return [];
         return frames.OfType<JsonObject>()
             .Reverse()
             .Select(f => new StacktraceFrameItem(
+                GetFrameImageName(f, images),
                 f.TryGetString("instruction_addr") ?? "",
                 demangler.Demangle(f.TryGetString("function") ?? "")))
             .ToList();
+    }
+
+    private static string GetFrameImageName(JsonObject frame, List<StacktraceImageItem> images)
+    {
+        var image = frame.TryGetString("package")
+                    ?? frame.TryGetString("module")
+                    ?? frame.TryGetString("filename")
+                    ?? frame.TryGetString("abs_path");
+        if (!string.IsNullOrEmpty(image))
+        {
+            return GetFileName(image);
+        }
+
+        return TryParseAddress(frame.TryGetString("instruction_addr"), out var address)
+            ? FindImageName(images, address)
+            : "";
+    }
+
+    private static List<StacktraceImageItem> ParseImages(JsonObject? payload)
+    {
+        if (payload?.TryGetProperty("debug_meta.images") is not JsonArray images)
+        {
+            return [];
+        }
+
+        return images.OfType<JsonObject>()
+            .Select(image =>
+            {
+                var file = image.TryGetString("code_file")
+                           ?? image.TryGetString("debug_file")
+                           ?? image.TryGetString("name");
+
+                if (string.IsNullOrEmpty(file)
+                    || !TryParseAddress(image.TryGetString("image_addr"), out var address)
+                    || !TryGetUlong(image.TryGetProperty("image_size"), out var size)
+                    || size == 0)
+                {
+                    return null;
+                }
+
+                return new StacktraceImageItem(address, size, GetFileName(file));
+            })
+            .OfType<StacktraceImageItem>()
+            .OrderBy(image => image.Address)
+            .ToList();
+    }
+
+    private static List<StacktraceImageItem> ParseImages(Minidump.ModuleList? moduleList)
+    {
+        if (moduleList is null) return [];
+
+        var images = new List<StacktraceImageItem>();
+        foreach (var module in moduleList.Modules.Where(module => module.SizeOfImage > 0))
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(module.Name))
+                {
+                    images.Add(new StacktraceImageItem(
+                        module.BaseOfImage,
+                        module.SizeOfImage,
+                        GetFileName(module.Name)));
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        return images.OrderBy(image => image.Address).ToList();
+    }
+
+    private static string FindImageName(List<StacktraceImageItem> images, ulong address)
+    {
+        var image = images.LastOrDefault(image => image.Contains(address));
+        return image?.Name ?? "";
+    }
+
+    private static string GetFileName(string path)
+    {
+        var normalized = path.TrimEnd('/', '\\');
+        var separator = normalized.LastIndexOfAny(['/', '\\']);
+        return separator >= 0 ? normalized[(separator + 1)..] : normalized;
+    }
+
+    private static bool TryParseAddress(string? value, out ulong address)
+    {
+        address = 0;
+        if (string.IsNullOrWhiteSpace(value)) return false;
+
+        value = value.Trim();
+        if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            return ulong.TryParse(value[2..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out address);
+        }
+
+        return ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out address);
+    }
+
+    private static bool TryGetUlong(JsonNode? node, out ulong value)
+    {
+        value = 0;
+        if (node is not JsonValue jsonValue) return false;
+
+        if (jsonValue.TryGetValue(out ulong ulongValue))
+        {
+            value = ulongValue;
+            return true;
+        }
+
+        if (jsonValue.TryGetValue(out long longValue) && longValue >= 0)
+        {
+            value = (ulong)longValue;
+            return true;
+        }
+
+        if (jsonValue.TryGetValue(out string? stringValue))
+        {
+            return TryParseAddress(stringValue, out value);
+        }
+
+        return false;
+    }
+
+    private sealed record StacktraceImageItem(ulong Address, ulong Size, string Name)
+    {
+        public bool Contains(ulong address) => address >= Address && address - Address < Size;
     }
 }

--- a/Sentry.CrashReporter/Views/StacktraceView.cs
+++ b/Sentry.CrashReporter/Views/StacktraceView.cs
@@ -137,6 +137,18 @@ internal class StacktraceFrameGrid : DataGrid
 
         Columns.Add(new DataGridTemplateColumn
         {
+            Header = "Image",
+            Width = DataGridLength.Auto,
+            CellTemplate = new DataTemplate(() =>
+                new TextBlock()
+                    .WithSourceCodePro()
+                    .Margin(new Thickness(8, 0))
+                    .VerticalAlignment(VerticalAlignment.Center)
+                    .Text(x => x.Binding("Image")))
+        });
+
+        Columns.Add(new DataGridTemplateColumn
+        {
             Header = "Address",
             Width = DataGridLength.Auto,
             CellTemplate = new DataTemplate(() =>
@@ -167,7 +179,10 @@ internal class StacktraceFrameGrid : DataGrid
             !SelectedItems.Contains(item))
         {
             SelectedIndex = items.IndexOf(item);
-            CurrentColumn = Columns[e.GetPosition(this).X < Columns[0].ActualWidth ? 0 : 1];
+            var position = e.GetPosition(this).X;
+            CurrentColumn = position < Columns[0].ActualWidth ? Columns[0]
+                : position < Columns[0].ActualWidth + Columns[1].ActualWidth ? Columns[1]
+                : Columns[2];
         }
     }
 
@@ -209,12 +224,12 @@ internal class StacktraceFrameGrid : DataGrid
         if (SelectedItems.Count > 1)
         {
             return string.Join("\n", SelectedItems.OfType<StacktraceFrameItem>()
-                .Select(x => $"{x.Address}\t{x.Symbol}"));
+                .Select(FormatFrame));
         }
 
         if (SelectedItem is StacktraceFrameItem frame)
         {
-            return $"{frame.Address}\t{frame.Symbol}";
+            return FormatFrame(frame);
         }
 
         return null;
@@ -225,6 +240,9 @@ internal class StacktraceFrameGrid : DataGrid
         if (ItemsSource is not List<StacktraceFrameItem> items || items.Count == 0)
             return null;
 
-        return string.Join("\n", items.Select(x => $"{x.Address}\t{x.Symbol}"));
+        return string.Join("\n", items.Select(FormatFrame));
     }
+
+    private static string FormatFrame(StacktraceFrameItem frame) =>
+        $"{frame.Image}\t{frame.Address}\t{frame.Symbol}";
 }

--- a/tests/Sentry.CrashReporter.RuntimeTests/StacktraceViewTests.cs
+++ b/tests/Sentry.CrashReporter.RuntimeTests/StacktraceViewTests.cs
@@ -114,6 +114,23 @@ public class StacktraceViewTests : RuntimeTestBase
     }
 
     [TestMethod]
+    public async Task StacktraceView_DisplaysFrameImage()
+    {
+        // Arrange
+        await using var file = OpenTestFile("data/crashpad.envelope");
+        var envelope = await Envelope.FromFileStreamAsync(file);
+        _ = MockRuntime(envelope);
+
+        // Act
+        var view = new StacktraceView().Envelope(envelope);
+        await LoadTestContent(view);
+
+        // Assert
+        var image = view.FindFirstDescendant<TextBlock>(tb => tb.Text == "VCRUNTIME140D.dll");
+        Assert.IsNotNull(image);
+    }
+
+    [TestMethod]
     public async Task StacktraceView_CrashedThreadHasBugIcon()
     {
         // Arrange
@@ -174,7 +191,7 @@ public class StacktraceViewTests : RuntimeTestBase
     }
 
     [TestMethod]
-    public async Task StacktraceView_FrameGridHasTwoColumns()
+    public async Task StacktraceView_FrameGridHasThreeColumns()
     {
         // Arrange
         await using var file = OpenTestFile("data/crashpad.envelope");
@@ -188,7 +205,7 @@ public class StacktraceViewTests : RuntimeTestBase
         // Assert
         var grid = view.FindFirstDescendant<StacktraceFrameGrid>();
         Assert.IsNotNull(grid);
-        Assert.AreEqual(2, grid.Columns.Count);
+        Assert.AreEqual(3, grid.Columns.Count);
     }
 
     [TestMethod]
@@ -209,7 +226,7 @@ public class StacktraceViewTests : RuntimeTestBase
 
         // Assert
         var selectedText = grid.GetSelectedText();
-        Assert.AreEqual("0x7FFC9BFA2766\tmemset", selectedText);
+        Assert.AreEqual("VCRUNTIME140D.dll\t0x7FFC9BFA2766\tmemset", selectedText);
     }
 
     [TestMethod]
@@ -358,7 +375,7 @@ public class StacktraceViewTests : RuntimeTestBase
         await UnitTestsUIContentHelper.WaitForIdle();
 
         // Assert
-        mockRuntime.Clipboard.Verify(c => c.SetText("0x7FFC9BFA2766\tmemset"), Times.Once);
+        mockRuntime.Clipboard.Verify(c => c.SetText("VCRUNTIME140D.dll\t0x7FFC9BFA2766\tmemset"), Times.Once);
     }
 
     [TestMethod]

--- a/tests/Sentry.CrashReporter.Tests/StacktraceViewModelTests.cs
+++ b/tests/Sentry.CrashReporter.Tests/StacktraceViewModelTests.cs
@@ -94,8 +94,10 @@ public class StacktraceViewModelTests
         // Assert
         Assert.That(viewModel.Frames, Is.Not.Null);
         Assert.That(viewModel.Frames, Has.Count.EqualTo(48));
+        Assert.That(viewModel.Frames![0].Image, Is.EqualTo("VCRUNTIME140D.dll"));
         Assert.That(viewModel.Frames![0].Address, Is.EqualTo("0x7FFC9BFA2766"));
         Assert.That(viewModel.Frames[0].Symbol, Is.EqualTo("memset"));
+        Assert.That(viewModel.Frames[1].Image, Is.EqualTo("sentry-playground.exe"));
     }
 
     [Test]
@@ -241,6 +243,7 @@ public class StacktraceViewModelTests
         Assert.That(viewModel.Threads![0].ThreadId, Is.EqualTo("1000"));
         Assert.That(viewModel.Threads[0].Crashed, Is.True);
         Assert.That(viewModel.Threads[0].Frames, Has.Count.EqualTo(7));
+        Assert.That(viewModel.Threads[0].Frames[0].Image, Is.Empty);
         Assert.That(viewModel.Threads[0].Frames[0].Address, Is.EqualTo("0x400500"));
         Assert.That(viewModel.Threads[0].Frames[0].Symbol, Is.EqualTo("crash_here"));
         Assert.That(viewModel.SelectedThreadIndex, Is.EqualTo(0));
@@ -351,6 +354,7 @@ public class StacktraceViewModelTests
         Assert.That(viewModel.Threads![0].ThreadId, Is.EqualTo("18732"));
         Assert.That(viewModel.Threads[0].Crashed, Is.True);
         Assert.That(viewModel.Threads[0].Frames, Has.Count.EqualTo(28));
+        Assert.That(viewModel.Threads[0].Frames[0].Image, Is.EqualTo("sentry-playground.exe"));
         Assert.That(viewModel.Threads[0].Frames[0].Symbol, Is.EqualTo("trigger_crash"));
     }
 


### PR DESCRIPTION
Display the image associated with each stacktrace frame from event debug metadata or minidump module streams. Include the image name when copying stacktrace rows.

| Before | After |
|---|---|
| <img width="1012" height="744" alt="Screenshot 2026-07-13 at 08 43 22" src="https://github.com/user-attachments/assets/bd6a220a-e306-4a97-be81-0f0b13b26384" /> | <img width="1012" height="744" alt="Screenshot 2026-07-13 at 08 41 47" src="https://github.com/user-attachments/assets/fb12e112-cb73-479a-802c-c4cead0767aa" /> |
