### PR TITLE
ci: prepare baseline update workflow for golden images

### DIFF
--- a/.github/workflows/commit-goldens.yml
+++ b/.github/workflows/commit-goldens.yml
@@ -165,7 +165,14 @@ jobs:
   remove_label:
     name: Remove Label
     needs: commit_goldens
-    if: ${{ needs.commit_goldens.result == 'success' }}
+    if: >-
+      ${{
+        always() &&
+        github.event.workflow_run.conclusion != 'skipped' &&
+        github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.head_repository.full_name == github.repository &&
+        github.event.workflow_run.pull_requests[0].number != null
+      }}
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: write

--- a/.github/workflows/commit-goldens.yml
+++ b/.github/workflows/commit-goldens.yml
@@ -1,0 +1,179 @@
+name: Commit Goldens
+
+on:
+  workflow_run:
+    workflows: [Update Goldens]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  detect_artifacts:
+    name: Detect Updated Goldens
+    if: >-
+      ${{
+        github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_repository.full_name == github.repository &&
+        github.event.workflow_run.pull_requests[0].number != null
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+    outputs:
+      found: ${{ steps.artifacts.outputs.found }}
+    steps:
+      - name: Find updated golden artifacts
+        id: artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          names=$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts" \
+            --jq '.artifacts[].name')
+
+          for name in \
+            updated-goldens-linux-x64 \
+            updated-goldens-osx-arm64 \
+            updated-goldens-win-x64; do
+            if ! grep -Fxq "$name" <<< "$names"; then
+              echo "found=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
+          echo "found=true" >> "$GITHUB_OUTPUT"
+
+  commit_goldens:
+    name: Commit Updated Goldens
+    needs: detect_artifacts
+    if: ${{ needs.detect_artifacts.outputs.found == 'true' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+    env:
+      HEAD_REF: ${{ github.event.workflow_run.head_branch }}
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - name: Download Updated Goldens
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: updated-goldens-*
+          path: ${{ runner.temp }}/updated-goldens
+          merge-multiple: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Validate Updated Goldens
+        shell: bash
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/updated-goldens
+        run: |
+          python3 -I - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          artifact_dir = Path(os.environ["ARTIFACT_DIR"])
+          name_pattern = re.compile(
+              r"^(linux-x64|osx-arm64|win-x64)-[a-z0-9-]+-(light|dark|default)\.png$")
+          png_signature = b"\x89PNG\r\n\x1a\n"
+          required_rids = {"linux-x64", "osx-arm64", "win-x64"}
+          found_rids = set()
+
+          for path in artifact_dir.rglob("*"):
+              if path.is_symlink() or not path.is_file() or path.parent != artifact_dir:
+                  raise SystemExit(f"Unexpected golden artifact entry: {path}")
+
+              match = name_pattern.fullmatch(path.name)
+              if match is None:
+                  raise SystemExit(f"Unexpected golden filename: {path.name}")
+              with path.open("rb") as file:
+                  signature = file.read(8)
+              if signature != png_signature:
+                  raise SystemExit(f"Invalid PNG signature: {path.name}")
+
+              found_rids.add(match.group(1))
+
+          if found_rids != required_rids:
+              missing = ", ".join(sorted(required_rids - found_rids))
+              raise SystemExit(f"Missing updated goldens for: {missing}")
+          PY
+
+      - name: Prepare golden commit
+        id: commit
+        shell: bash
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/updated-goldens
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_INDEX_FILE: ${{ runner.temp }}/golden-index
+          REPO_DIR: ${{ runner.temp }}/golden-repo
+        run: |
+          git init --quiet "$REPO_DIR"
+          git -C "$REPO_DIR" fetch --quiet --no-tags --depth=1 \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "$HEAD_SHA"
+          git -C "$REPO_DIR" read-tree "$HEAD_SHA"
+
+          for path in "$ARTIFACT_DIR"/*.png; do
+            name=${path##*/}
+            blob=$(git -C "$REPO_DIR" hash-object -w -- "$path")
+            git -C "$REPO_DIR" update-index --add --cacheinfo \
+              100644 "$blob" "tests/goldens/$name"
+          done
+
+          tree=$(git -C "$REPO_DIR" write-tree)
+          if test "$tree" = "$(git -C "$REPO_DIR" rev-parse "${HEAD_SHA}^{tree}")"; then
+            echo "::notice::No golden changes."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          commit=$(git -C "$REPO_DIR" \
+            -c user.name="github-actions[bot]" \
+            -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+            commit-tree "$tree" -p "$HEAD_SHA" -m "test(goldens): update baselines")
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "sha=$commit" >> "$GITHUB_OUTPUT"
+
+      - name: Get auth token
+        id: token
+        if: ${{ steps.commit.outputs.changed == 'true' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
+      - name: Commit updated goldens
+        if: ${{ steps.commit.outputs.changed == 'true' }}
+        shell: bash
+        env:
+          COMMIT_SHA: ${{ steps.commit.outputs.sha }}
+          GH_APP_TOKEN: ${{ steps.token.outputs.token }}
+          REPO_DIR: ${{ runner.temp }}/golden-repo
+        run: |
+          git -C "$REPO_DIR" push \
+            "https://x-access-token:${GH_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "${COMMIT_SHA}:refs/heads/${HEAD_REF}"
+
+  remove_label:
+    name: Remove Label
+    needs: commit_goldens
+    if: ${{ needs.commit_goldens.result == 'success' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+    env:
+      PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+    steps:
+      - name: Remove update-goldens label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: gh pr edit "$PR_NUMBER" --remove-label update-goldens


### PR DESCRIPTION
PR #262 will use the workflow when _Update Goldens_ completes. It downloads and validates that run's artifacts, creates and pushes the baseline commit to the PR branch, and removes the `update-goldens` label.

Submitted separately because GitHub only starts `workflow_run` when it already exists on the default branch.